### PR TITLE
Preserve internal page links & diagrams; modern/localized Collectives support

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,27 @@ python migrate.py upload --target-parent MigratedPages
 python migrate.py status
 ```
 
+### Space Templates
+
+Confluence space page-templates can be imported as native Collectives page
+templates (they land in the collective's hidden `.templates/` folder and show up
+in the New-page template picker):
+
+```bash
+# Import a space's templates (standalone)
+python migrate.py import-templates --space SPACE_KEY
+
+# Preview without writing (needs only Confluence credentials)
+python migrate.py import-templates --space SPACE_KEY --dry-run
+
+# Or fold templates into a full migration run
+python migrate.py migrate --space SPACE_KEY --include-templates
+```
+
+Template bodies come from Confluence in *storage* format (templates have no
+rendered `export_view`). Template variables such as `<at:var at:name="Owner"/>`
+are rendered as `{{Owner}}` placeholders. See **Limitations** for macro handling.
+
 ### Command Options
 
 | Option | Commands | Description |
@@ -152,6 +173,8 @@ python migrate.py status
 | `--exclude-images` | export, convert, migrate | Skip image attachments |
 | `--exclude-attachments` | export, convert, migrate | Skip all attachments |
 | `--target-parent NAME` | upload, migrate | Top folder in the collective (default: `MigratedPages`). Use `''` to import at the collective base — the space homepage becomes the landing page |
+| `--include-templates` | migrate | Also import the space's page-templates into the collective's `.templates/` folder (requires `--space`) |
+| `--space KEY` | import-templates | Confluence space whose page-templates to import (required) |
 | `--dry-run` | all | Preview actions without changes |
 | `--debug` | all | Enable debug logging |
 | `--log-file PATH` | all | Write logs to file |
@@ -197,6 +220,7 @@ convert_data/{space_key}/         # Phase 2 output (uploaded in Phase 3)
 - **Footer comments only** — Inline comments (annotations on specific text) are not migrated; footer comments and their reply chains are fully supported.
 - **No permission migration** — Page-level permissions from Confluence are not transferred.
 - **Unsupported macros** — Diagram macros (Draw.io, Gliffy, etc.) render via their static image preview, but other third-party macro content (e.g. Jira) is replaced with HTML comments. SVG diagram previews are demoted to attachment links, since Collectives blocks SVG rendering.
+- **Space templates** — Imported template bodies are storage-format XHTML (templates have no rendered `export_view`), so any macro inside a template is *unexpanded*: it is surfaced as a visible `[Unsupported macro: NAME]` marker and its body is dropped. Template variables become `{{Name}}` placeholders. A renamed template leaves its old file behind (uploads overwrite by path; they do not purge).
 - **Sequential processing** — Pages are processed one at a time (no parallel downloads).
 - **Filename length** — Titles are capped at 200 characters; special characters are stripped.
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,24 @@ CLI tool to migrate pages and attachments from Confluence Cloud to Nextcloud Col
 The tool runs a three-phase pipeline:
 
 1. **Export** — Fetches pages via the Confluence Cloud REST API v2 (`body-format=export_view` for clean HTML), downloads attachments, and stores everything locally in `export_data/`.
-2. **Convert** — Transforms Confluence HTML to Markdown using BeautifulSoup (preprocessing) + html2text (conversion). Builds the output directory tree matching page hierarchy. Copies attachments alongside their pages.
-3. **Upload** — Pushes the converted Markdown files and attachments to Nextcloud Collectives via WebDAV (`MKCOL` for directories, `PUT` for files).
+2. **Convert** — Transforms Confluence HTML to Markdown using BeautifulSoup (preprocessing) + html2text (conversion). Builds the output directory tree matching page hierarchy. Copies attachments alongside their pages. Links to other migrated pages are tagged with a `cpage:<id>` placeholder for the upload phase to resolve, and diagram/image macro previews are lifted out so they render as static images.
+3. **Upload** — Resolves the target collective via the Collectives OCS API, then pushes the converted Markdown files and attachments to Nextcloud Collectives via WebDAV (`MKCOL` for directories, `PUT` for files). The `cpage:` placeholders are resolved per source page into **relative** links between the output pages, so they survive renaming the collective or moving its pages.
 
 Each phase tracks per-page status in `.migration-state.json`, enabling resumable migrations and independent re-runs of any phase.
+
+### Internal Links & Diagrams
+
+- **Internal page links** between migrated pages are preserved as relative links between the output pages. Relative links are collective-agnostic, so they keep working if the collective is renamed or its pages are moved to another collective. The collective's root/landing page is the one exception (it has no trailing URL segment to be relative to), and uses an absolute `/apps/collectives/<slug>-<id>/...` link instead.
+- **Diagrams and images** from draw.io / Gliffy / etc. macros render as static images: the macro's rendered `<img>` preview (embedded by `export_view`) is lifted out before the macro itself is dropped. SVG previews stay demoted to an attachment link, since Collectives blocks SVG rendering.
+
+### Modern / Localized / Shared Collectives
+
+`verify_connection` resolves the target collective via the Collectives OCS API, matching `NEXTCLOUD_COLLECTIVE` by display name, slug, or `<slug>-<id>`. This handles:
+
+- The hidden, **localized** storage folder — a German Nextcloud stores collectives under `.Kollektive` rather than `.Collectives` (read from a page's `collectivePath`).
+- The WebDAV folder being the collective's display name, while the link URL segment is `<slug>-<id>`.
+
+If the OCS API is unavailable, it falls back to probing `.Collectives` then `Collectives`. Attachment links use the open-by-id `.../f/<id>` URL so they resolve even from the hidden storage folder.
 
 ### Page Hierarchy Mapping
 
@@ -105,6 +119,9 @@ python migrate.py migrate --space SPACE_KEY --exclude-attachments
 
 # Specify target parent page in Collectives
 python migrate.py migrate --space SPACE_KEY --target-parent "Imported from Confluence"
+
+# Import directly at the collective base (space homepage becomes the landing page)
+python migrate.py migrate --space SPACE_KEY --target-parent ''
 ```
 
 ### Individual Phases
@@ -134,7 +151,7 @@ python migrate.py status
 | `--all-spaces` | export, migrate | Migrate all accessible spaces |
 | `--exclude-images` | export, convert, migrate | Skip image attachments |
 | `--exclude-attachments` | export, convert, migrate | Skip all attachments |
-| `--target-parent NAME` | upload, migrate | Parent page in Collectives (default: `MigratedPages`) |
+| `--target-parent NAME` | upload, migrate | Top folder in the collective (default: `MigratedPages`). Use `''` to import at the collective base — the space homepage becomes the landing page |
 | `--dry-run` | all | Preview actions without changes |
 | `--debug` | all | Enable debug logging |
 | `--log-file PATH` | all | Write logs to file |
@@ -164,12 +181,14 @@ convert_data/{space_key}/         # Phase 2 output (uploaded in Phase 3)
 | Page body | Clean Markdown |
 | Tables (even with headings in cells) | Markdown tables |
 | Images | `![alt](image.png)` with relative paths |
+| Diagram macros (Draw.io, Gliffy, etc.) | Rendered preview lifted out as a static `![](…)` image |
+| Internal page links | Relative links between the migrated pages (move/rename-safe) |
 | Code blocks | Fenced code blocks with language hints |
-| Info/warning/note/tip panels | Blockquotes with bold prefix |
+| Info/warning/note/tip panels | Plain blockquotes (no duplicated `Info:`/`Note:` label) |
 | User mentions | `@DisplayName` |
 | Footer comments | `## Comments` section with author and date |
-| Non-image attachments | `## Attachments` section with links |
-| Unsupported macros (Jira, Draw.io, etc.) | HTML comment: `<!-- Unsupported macro: name -->` |
+| Non-image attachments | `## Attachments` section with `-` bulleted links |
+| Other unsupported macros (Jira, etc.) | HTML comment: `<!-- Unsupported macro: name -->` |
 | Attachment management UI | Removed (tool generates its own section) |
 
 ## Limitations
@@ -177,7 +196,7 @@ convert_data/{space_key}/         # Phase 2 output (uploaded in Phase 3)
 - **Confluence Cloud only** — Confluence Server/Data Center API differences are not handled.
 - **Footer comments only** — Inline comments (annotations on specific text) are not migrated; footer comments and their reply chains are fully supported.
 - **No permission migration** — Page-level permissions from Confluence are not transferred.
-- **Unsupported macros** — Jira, Draw.io, and other third-party macro content is replaced with HTML comments.
+- **Unsupported macros** — Diagram macros (Draw.io, Gliffy, etc.) render via their static image preview, but other third-party macro content (e.g. Jira) is replaced with HTML comments. SVG diagram previews are demoted to attachment links, since Collectives blocks SVG rendering.
 - **Sequential processing** — Pages are processed one at a time (no parallel downloads).
 - **Filename length** — Titles are capped at 200 characters; special characters are stripped.
 
@@ -217,6 +236,15 @@ The `.mcp.json` file configures two MCP servers for development and testing:
 These are development tools only — `migrate.py` has zero MCP dependency and uses direct HTTP requests.
 
 ## Changelog
+
+### Unreleased
+
+- Internal page links between migrated pages are preserved as relative links (survive renaming the collective or moving its pages); the collective's landing page uses an absolute `/apps/collectives/<slug>-<id>/...` link
+- Diagram macros (Draw.io, Gliffy, etc.) now render as static images — the rendered preview is lifted out of the macro instead of being dropped
+- Resolve the target collective via the Collectives OCS API: supports modern/localized/shared collectives (e.g. a German Nextcloud's `.Kollektive` storage folder), matches by name / slug / `<slug>-<id>`, and falls back to probing `.Collectives`/`Collectives`
+- Attachment links use the open-by-id `.../f/<id>` URL so they resolve even from the hidden storage folder
+- `--target-parent ''` imports directly at the collective base (the space homepage becomes the landing page) instead of nesting under a top folder
+- Fix: attachment list `-` bullets are preserved; Info/Warning/Note/Tip panels become plain blockquotes without a duplicated `Info:`/`Note:` label
 
 ### 0.6.0
 

--- a/migrate.py
+++ b/migrate.py
@@ -497,6 +497,11 @@ class Converter:
                 new_pre.append(code_tag)
                 code_macro.replace_with(new_pre)
 
+        # Storage-format status lozenges → inline code (same as the export_view
+        # status handler). Runs before the details handler so statuses inside a
+        # details table are converted before that table is extracted/dropped.
+        self._replace_storage_status_macros(soup)
+
         # Details (page-properties) macro: extract its inner table so the content
         # survives (or drop it entirely when exclude_details). Runs before the
         # generic handler below, else it degrades to an "Unsupported macro" marker.
@@ -568,6 +573,23 @@ class Converter:
             code = soup.new_tag("code")
             code.string = text
             span.replace_with(code)
+
+    def _replace_storage_status_macros(self, soup):
+        """Storage-format status lozenges (`<ac:structured-macro ac:name="status">`
+        with a `title` parameter) → inline `<code>`, the same pill treatment the
+        export_view handler gives `span.status-macro`. Storage only, so a no-op for
+        export_view pages."""
+        for macro in soup.find_all("ac:structured-macro", {"ac:name": "status"}):
+            if getattr(macro, "decomposed", False):
+                continue
+            title = macro.find("ac:parameter", {"ac:name": "title"})
+            text = title.get_text(strip=True) if title else ""
+            if text:
+                code = soup.new_tag("code")
+                code.string = text
+                macro.replace_with(code)
+            else:
+                macro.decompose()
 
     def _handle_details_macros(self, soup):
         """Confluence "details" (page-properties) macros wrap a properties table in

--- a/migrate.py
+++ b/migrate.py
@@ -6,6 +6,7 @@ __version__ = "0.6.0"
 import json
 import logging
 import os
+import posixpath
 import re
 import shutil
 import sys
@@ -294,12 +295,27 @@ class ConfluenceClient:
     def get_page_attachments(self, page_id):
         return list(self._paginate(f"/wiki/api/v2/pages/{page_id}/attachments"))
 
-    def download_attachment(self, download_url):
-        """Download attachment binary. Prepends /wiki to relative URLs."""
-        if download_url.startswith("/download/") or download_url.startswith("/rest/"):
-            download_url = f"/wiki{download_url}"
-        resp = self._request("GET", download_url)
-        return resp.content
+    def download_attachment(self, content_id, attachment_id, fallback_url=None):
+        """Download an attachment binary.
+
+        Uses the REST route /wiki/rest/api/content/{id}/child/attachment/{attId}/download,
+        which honours API-token Basic auth and 302-redirects to the media binary.
+        The attachment's own `downloadLink` instead points at the legacy
+        /wiki/download servlet, which rejects API tokens (HTTP 401 + "OAuth"
+        challenge) on Cloud sites — so it is only used as a last-resort fallback.
+        """
+        try:
+            url = (
+                f"/wiki/rest/api/content/{content_id}"
+                f"/child/attachment/{attachment_id}/download"
+            )
+            return self._request("GET", url).content
+        except requests.HTTPError:
+            if fallback_url:
+                if fallback_url.startswith("/download/") or fallback_url.startswith("/rest/"):
+                    fallback_url = f"/wiki{fallback_url}"
+                return self._request("GET", fallback_url).content
+            raise
 
 
 # ---------------------------------------------------------------------------
@@ -312,9 +328,18 @@ class Converter:
 
     UNSAFE_FILENAME_RE = re.compile(r'[/\\:*?"<>|]')
 
+    # Matches a Confluence page id in an internal link, e.g.
+    #   /wiki/spaces/TEAM/pages/67890/Other+Page
+    #   https://x.atlassian.net/wiki/spaces/TEAM/pages/67890
+    PAGE_LINK_RE = re.compile(r"/pages/(\d+)")
+
     def __init__(self, exclude_images=False, exclude_attachments=False):
         self.exclude_images = exclude_images
         self.exclude_attachments = exclude_attachments
+        # page_id -> output path relative to the space root (e.g. "Section/Leaf.md").
+        # Populated via set_link_map() so internal page links can be rewritten to
+        # relative links between the migrated Markdown files.
+        self.page_link_map = {}
         self._h2t = html2text.HTML2Text()
         self._h2t.body_width = 0
         self._h2t.protect_links = True
@@ -325,8 +350,12 @@ class Converter:
 
     # -- preprocessing ----------------------------------------------------
 
-    def preprocess_html(self, html, attachment_names=None):
-        """Clean Confluence HTML before markdown conversion."""
+    def preprocess_html(self, html, attachment_names=None, current_path=None):
+        """Clean Confluence HTML before markdown conversion.
+
+        current_path: output path of the page being converted (relative to the
+        space root); enables internal-link rewriting when a link map is set.
+        """
         soup = BeautifulSoup(html, "html.parser")
 
         # Remove leading <hr> tags — html2text converts them to "---" which
@@ -431,10 +460,12 @@ class Converter:
                 new_pre.append(code_tag)
                 code_macro.replace_with(new_pre)
 
-        # ac:structured-macro and data-macro-name → HTML comments
+        # ac:structured-macro and data-macro-name → HTML comments, BUT keep any
+        # rendered image inside (draw.io / Gliffy / etc. embed a PNG preview in
+        # export_view) so diagrams still show up in Collectives.
         for macro in soup.find_all("ac:structured-macro"):
             name = macro.get("ac:name", "unknown")
-            macro.replace_with(Comment(f" Unsupported macro: {name} "))
+            self._replace_unsupported_macro(soup, macro, name)
 
         for macro in soup.find_all("div", attrs={"data-macro-name": True}):
             # Skip already-handled panels and code blocks
@@ -444,7 +475,7 @@ class Converter:
             ):
                 continue
             name = macro.get("data-macro-name", "unknown")
-            macro.replace_with(Comment(f" Unsupported macro: {name} "))
+            self._replace_unsupported_macro(soup, macro, name)
 
         # User mentions → @DisplayName
         for mention in soup.find_all("a", class_="confluence-userlink"):
@@ -472,19 +503,71 @@ class Converter:
             for img in soup.find_all("img"):
                 img.decompose()
 
+        # Rewrite internal page-to-page links to relative Markdown links so they
+        # keep working inside Collectives (no-op unless a link map + current path
+        # are supplied via set_link_map() / convert_page(current_page_id=...)).
+        if self.page_link_map and current_path is not None:
+            self._rewrite_internal_links(soup, current_path)
+
         return str(soup)
 
+    def _replace_unsupported_macro(self, soup, macro, name):
+        """Drop an unsupported macro, but lift out any rendered <img> it wraps.
+
+        Confluence renders draw.io/Gliffy/etc. macros to a PNG preview inside the
+        macro element in export_view. Keeping that image lets the diagram render
+        in Collectives; the later image-src rewrite turns it into a local file
+        reference. Macros with no image become an HTML comment as before.
+        """
+        imgs = macro.find_all("img")
+        if imgs:
+            wrapper = soup.new_tag("p")
+            for img in imgs:
+                wrapper.append(img.extract())
+            macro.replace_with(wrapper)
+        else:
+            macro.replace_with(Comment(f" Unsupported macro: {name} "))
+
+    def _rewrite_internal_links(self, soup, current_path):
+        """Rewrite <a> links targeting migrated Confluence pages to relative
+        links between the output Markdown files. Links to pages outside the
+        migrated set (or non-page links) are left untouched."""
+        current_dir = posixpath.dirname(current_path)
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            m = self.PAGE_LINK_RE.search(href)
+            if not m:
+                continue
+            target_path = self.page_link_map.get(m.group(1))
+            if not target_path:
+                continue  # target page not part of this migration — leave as-is
+            anchor = ""
+            if "#" in href:
+                anchor = "#" + href.split("#", 1)[1]
+            rel = posixpath.relpath(target_path, current_dir or ".")
+            rel = "/".join(quote(seg) for seg in rel.split("/"))
+            a["href"] = rel + anchor
+
     # -- conversion -------------------------------------------------------
+
+    def set_link_map(self, page_link_map):
+        """Provide {page_id: output_path} so internal links can be rewritten."""
+        self.page_link_map = page_link_map or {}
 
     def html_to_markdown(self, html):
         """Convert HTML to markdown via html2text."""
         return self._h2t.handle(html).strip()
 
-    def convert_page(self, page_data, attachments_dir=None):
-        """Full page conversion: preprocess → markdown → comments → attachments."""
+    def convert_page(self, page_data, attachments_dir=None, current_page_id=None):
+        """Full page conversion: preprocess → markdown → comments → attachments.
+
+        current_page_id: the Confluence page id being converted; used with the
+        link map to rewrite internal page links relative to this page.
+        """
         html = page_data.get("body", "")
         attachment_names = [a["title"] for a in page_data.get("attachments", [])]
-        processed = self.preprocess_html(html, attachment_names)
+        current_path = self.page_link_map.get(str(current_page_id)) if current_page_id else None
+        processed = self.preprocess_html(html, attachment_names, current_path=current_path)
         md = self.html_to_markdown(processed)
 
         # Append comments
@@ -666,32 +749,63 @@ class Converter:
 class NextcloudClient:
     """Nextcloud WebDAV client for Collectives."""
 
+    # Collectives stores pages in a folder inside the user's files. Recent
+    # versions (Collectives 4.x / Nextcloud 28+) use the HIDDEN ".Collectives";
+    # older versions used "Collectives". Probed in verify_connection().
+    COLLECTIVES_DIRS = (".Collectives", "Collectives")
+
     def __init__(self, base_url, username, password, collective):
         self.base_url = base_url.rstrip("/")
         self.username = username
         self.collective = collective
-        self.dav_base = f"{self.base_url}/remote.php/dav/files/{username}/Collectives/{collective}"
+        self.files_base = f"{self.base_url}/remote.php/dav/files/{username}"
+        # Default to the modern hidden folder; verify_connection() may switch to
+        # the legacy name if that is what the server actually exposes.
+        self.collectives_dir = self.COLLECTIVES_DIRS[0]
         self.session = requests.Session()
         self.session.auth = (username, password)
 
+    @property
+    def dav_base(self):
+        return f"{self.files_base}/{self.collectives_dir}/{self.collective}"
+
     def verify_connection(self):
-        """Verify we can reach the collective via PROPFIND."""
-        resp = self.session.request("PROPFIND", self.dav_base, headers={"Depth": "0"})
-        if resp.status_code == 401:
-            raise click.ClickException("Nextcloud authentication failed — check credentials.")
-        if resp.status_code == 404:
+        """Verify we can reach the collective, auto-detecting the storage folder.
+
+        Tries ".Collectives/<name>" then "Collectives/<name>" so the tool works
+        against both modern and legacy Collectives without configuration.
+        """
+        last_status = None
+        for candidate in self.COLLECTIVES_DIRS:
+            self.collectives_dir = candidate
+            resp = self.session.request("PROPFIND", self.dav_base, headers={"Depth": "0"})
+            if resp.status_code == 401:
+                raise click.ClickException("Nextcloud authentication failed — check credentials.")
+            if resp.status_code in (200, 207):
+                log.info(
+                    "Connected to Nextcloud collective: %s (under %s)",
+                    self.collective, candidate,
+                )
+                return
+            last_status = resp.status_code
+
+        if last_status == 404:
             raise click.ClickException(
-                f"Collective '{self.collective}' not found at {self.dav_base}"
+                f"Collective '{self.collective}' not found under "
+                f"{'/'.join(self.COLLECTIVES_DIRS)} for user {self.username}."
             )
-        if resp.status_code not in (200, 207):
-            raise click.ClickException(
-                f"Nextcloud PROPFIND failed with status {resp.status_code}"
-            )
-        log.info("Connected to Nextcloud collective: %s", self.collective)
+        raise click.ClickException(
+            f"Nextcloud PROPFIND failed with status {last_status}"
+        )
+
+    @staticmethod
+    def _remote(path):
+        """Normalise a remote path for WebDAV URLs (Windows backslashes → '/')."""
+        return path.replace("\\", "/")
 
     def mkdir_p(self, path):
         """Recursively create directories via MKCOL."""
-        parts = path.strip("/").split("/")
+        parts = self._remote(path).strip("/").split("/")
         current = self.dav_base
         for part in parts:
             if not part:
@@ -704,6 +818,7 @@ class NextcloudClient:
     def upload_file(self, local_path, remote_path):
         """Upload a file via PUT."""
         import mimetypes
+        remote_path = self._remote(remote_path)
         url = f"{self.dav_base}/{remote_path.lstrip('/')}"
         content_type = mimetypes.guess_type(local_path)[0] or "application/octet-stream"
         with open(local_path, "rb") as f:
@@ -718,6 +833,7 @@ class NextcloudClient:
         """Get Nextcloud file ID via PROPFIND."""
         import xml.etree.ElementTree as ET
 
+        remote_path = self._remote(remote_path)
         url = f"{self.dav_base}/{remote_path.lstrip('/')}"
         body = (
             '<?xml version="1.0"?>'
@@ -745,7 +861,7 @@ class NextcloudClient:
 
     def exists(self, path):
         """Check if a remote path exists via PROPFIND depth 0."""
-        url = f"{self.dav_base}/{path.lstrip('/')}"
+        url = f"{self.dav_base}/{self._remote(path).lstrip('/')}"
         resp = self.session.request("PROPFIND", url, headers={"Depth": "0"})
         return resp.status_code in (200, 207)
 
@@ -940,14 +1056,12 @@ def export(space_key, pages, all_spaces, exclude_images, exclude_attachments, dr
                             if exclude_images and ext in image_exts:
                                 continue
 
-                            download_url = att.get("downloadLink", "")
-                            if not download_url:
-                                # Fallback: try _links.download
-                                download_url = att.get("_links", {}).get("download", "")
+                            att_id = att.get("id")
+                            fallback = att.get("downloadLink") or att.get("_links", {}).get("download")
 
-                            if download_url:
+                            if att_id or fallback:
                                 try:
-                                    data = client.download_attachment(download_url)
+                                    data = client.download_attachment(page_id, att_id, fallback_url=fallback)
                                     att_dir.mkdir(parents=True, exist_ok=True)
                                     (att_dir / att_title).write_bytes(data)
                                     attachments.append({
@@ -1033,6 +1147,7 @@ def convert(exclude_images, exclude_attachments, dry_run, debug, log_file):
 
     converter = Converter(exclude_images=exclude_images, exclude_attachments=exclude_attachments)
     tree = converter.build_output_tree(state)
+    converter.set_link_map({pid: info["path"] for pid, info in tree.items()})
 
     if dry_run:
         click.echo(f"\n[DRY RUN] {len(exported)} page(s) to convert:")
@@ -1069,7 +1184,7 @@ def convert(exclude_images, exclude_attachments, dry_run, debug, log_file):
             output_dir = convert_base / path_info["dir"] if path_info["dir"] else convert_base
 
             # Convert to markdown
-            md = converter.convert_page(page_data)
+            md = converter.convert_page(page_data, current_page_id=pid)
 
             # Write markdown
             output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1158,7 +1273,7 @@ def upload(target_parent, dry_run, debug, log_file):
     # Ensure all parent directories are created
     created_dirs = set()
     for local_file in all_files:
-        parent_dirs = str(local_file.relative_to(convert_base).parent)
+        parent_dirs = local_file.relative_to(convert_base).parent.as_posix()
         if parent_dirs and parent_dirs != "." and parent_dirs not in created_dirs:
             nc.mkdir_p(f"{target_parent}/{parent_dirs}")
             created_dirs.add(parent_dirs)
@@ -1168,13 +1283,13 @@ def upload(target_parent, dry_run, debug, log_file):
     attachment_urls = {}
     for local_file in attachment_files:
         relative = local_file.relative_to(convert_base)
-        remote_path = f"{target_parent}/{relative}"
+        remote_path = f"{target_parent}/{relative.as_posix()}"
         try:
             nc.upload_file(str(local_file), remote_path)
             log.info("Uploaded attachment: %s", remote_path)
             file_id = nc.get_file_id(remote_path)
             if file_id:
-                remote_dir = str(relative.parent) if str(relative.parent) != "." else ""
+                remote_dir = relative.parent.as_posix() if str(relative.parent) != "." else ""
                 full_remote_dir = f"{target_parent}/{remote_dir}".rstrip("/")
                 encoded_name = quote(local_file.name)
                 attachment_urls.setdefault(full_remote_dir, {})[encoded_name] = \
@@ -1187,8 +1302,8 @@ def upload(target_parent, dry_run, debug, log_file):
     uploaded_pages = set()
     for local_file in md_files:
         relative = local_file.relative_to(convert_base)
-        remote_path = f"{target_parent}/{relative}"
-        remote_dir = str(relative.parent) if str(relative.parent) != "." else ""
+        remote_path = f"{target_parent}/{relative.as_posix()}"
+        remote_dir = relative.parent.as_posix() if str(relative.parent) != "." else ""
         full_remote_dir = f"{target_parent}/{remote_dir}".rstrip("/")
 
         try:
@@ -1365,12 +1480,11 @@ def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
                             ext = Path(att_title).suffix.lower()
                             if exclude_images and ext in image_exts:
                                 continue
-                            download_url = att.get("downloadLink", "")
-                            if not download_url:
-                                download_url = att.get("_links", {}).get("download", "")
-                            if download_url:
+                            att_id = att.get("id")
+                            fallback = att.get("downloadLink") or att.get("_links", {}).get("download")
+                            if att_id or fallback:
                                 try:
-                                    data = conf_client.download_attachment(download_url)
+                                    data = conf_client.download_attachment(page_id, att_id, fallback_url=fallback)
                                     att_dir.mkdir(parents=True, exist_ok=True)
                                     (att_dir / att_title).write_bytes(data)
                                     attachments.append({"title": att_title, "size": len(data), "mediaType": att.get("mediaType", "")})
@@ -1430,6 +1544,7 @@ def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
     converter = Converter(exclude_images=exclude_images, exclude_attachments=exclude_attachments)
     exported = state.get_pages_by_status("exported")
     tree = converter.build_output_tree(state)
+    converter.set_link_map({pid: info["path"] for pid, info in tree.items()})
 
     for pid, page_rec in exported.items():
         title = page_rec.get("title", "?")
@@ -1451,7 +1566,7 @@ def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
             output_path = convert_base / path_info["path"]
             output_dir = convert_base / path_info["dir"] if path_info["dir"] else convert_base
 
-            md = converter.convert_page(page_data)
+            md = converter.convert_page(page_data, current_page_id=pid)
             output_path.parent.mkdir(parents=True, exist_ok=True)
             output_path.write_text(md, encoding="utf-8")
 
@@ -1505,9 +1620,9 @@ def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
 
         convert_file = Path(convert_path)
         relative = convert_file.relative_to(convert_base)
-        remote_path = f"{target_parent}/{relative}"
+        remote_path = f"{target_parent}/{relative.as_posix()}"
 
-        parent_dirs = str(relative.parent)
+        parent_dirs = relative.parent.as_posix()
         if parent_dirs and parent_dirs != ".":
             nc.mkdir_p(f"{target_parent}/{parent_dirs}")
 
@@ -1519,7 +1634,7 @@ def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
             for f in output_dir.iterdir():
                 if f.is_file() and f != convert_file and f.suffix != ".md":
                     f_relative = f.relative_to(convert_base)
-                    f_remote = f"{target_parent}/{f_relative}"
+                    f_remote = f"{target_parent}/{f_relative.as_posix()}"
                     nc.upload_file(str(f), f_remote)
                     log.debug("Uploaded attachment: %s", f_remote)
 

--- a/migrate.py
+++ b/migrate.py
@@ -574,8 +574,11 @@ class Converter:
         an <ac:rich-text-body>. By default, unwrap that table so its content
         survives (the generic macro handler would otherwise drop it to a marker).
         When exclude_details is set, remove the macro and its body entirely."""
-        for macro in soup.find_all("ac:structured-macro"):
-            if macro.get("ac:name") != "details":
+        # Filter to details macros only: a details box nests other macros (e.g.
+        # status), and decomposing the parent would invalidate those if they were
+        # in the iteration list. The decomposed guard covers details-in-details.
+        for macro in soup.find_all("ac:structured-macro", {"ac:name": "details"}):
+            if getattr(macro, "decomposed", False):
                 continue
             body = macro.find("ac:rich-text-body")
             if self.exclude_details or not body:

--- a/migrate.py
+++ b/migrate.py
@@ -358,6 +358,11 @@ class Converter:
         """
         soup = BeautifulSoup(html, "html.parser")
 
+        # Status macros (lozenges, e.g. "IN ARBEIT" / "ABGELEHNT") → inline code.
+        # Runs early so status keywords inside panels and table cells are caught
+        # before those blocks are flattened/converted.
+        self._replace_status_macros(soup)
+
         # Remove leading <hr> tags — html2text converts them to "---" which
         # Nextcloud Collectives misinterprets as YAML front matter
         for el in soup.find_all("hr"):
@@ -499,6 +504,22 @@ class Converter:
             self._rewrite_internal_links(soup, current_path)
 
         return str(soup)
+
+    def _replace_status_macros(self, soup):
+        """Confluence status macros render as a lozenge span in export_view
+        (`<span class="status-macro aui-lozenge …">IN ARBEIT</span>`). Collectives
+        has no equivalent, so turn each into an inline `<code>` element — html2text
+        emits it as backtick-wrapped inline code (e.g. `IN ARBEIT`), keeping the
+        keyword visually distinct.
+        """
+        for span in soup.find_all("span", class_="status-macro"):
+            text = span.get_text(strip=True)
+            if not text:
+                span.decompose()
+                continue
+            code = soup.new_tag("code")
+            code.string = text
+            span.replace_with(code)
 
     def _replace_unsupported_macro(self, soup, macro, name):
         """Drop an unsupported macro, but lift out any rendered <img> it wraps.

--- a/migrate.py
+++ b/migrate.py
@@ -950,29 +950,57 @@ def page_route_segments(output_rel_path):
     return [seg for seg in p.split("/") if seg]
 
 
-def build_page_link_map(state, target_parent, collective):
-    """Map Confluence page_id -> absolute Collectives page URL, for resolving
-    `cpage:` placeholders. Collectives resolves internal links by walking the
-    page-title path under the collective, so the URL is
-    /apps/collectives/<collective>/<target_parent>/<title path>.
+def build_page_routes(state, target_parent):
+    """Map Confluence page_id -> Collectives route (page-title segments from the
+    collective root). target_parent is the optional top folder; '' imports
+    directly at the collective base (the space homepage becomes the landing page).
     """
-    link_map = {}
+    prefix = [target_parent] if target_parent else []
+    routes = {}
     for pid, rec in state.pages.items():
         convert_path = rec.get("convert_path")
         if not convert_path:
             continue
         space_key = rec.get("space_key", "default")
         rel = Path(convert_path).relative_to(Path("convert_data") / space_key).as_posix()
-        segments = [collective, target_parent, *page_route_segments(rel)]
-        link_map[pid] = "/apps/collectives/" + "/".join(quote(s) for s in segments)
-    return link_map
+        routes[pid] = prefix + page_route_segments(rel)
+    return routes
 
 
-def resolve_page_links(content, link_map):
-    """Replace `cpage:<id>` placeholders in Markdown with real Collectives URLs."""
+def _relative_route_link(target_route, source_route):
+    """Relative href from a source page to a target page (both route-segment
+    lists). The browser resolves a relative link against the source page's URL
+    with its last segment dropped, so the base is source_route[:-1]; a shared
+    parent prefix cancels out, leaving a collective-agnostic link."""
+    base = "/".join(source_route[:-1]) or "."
+    target = "/".join(target_route) or "."
+    rel = posixpath.relpath(target, base)
+    return "/".join(quote(seg) for seg in rel.split("/"))
+
+
+def resolve_page_links(content, source_route, page_routes, collective_segment):
+    """Replace `cpage:<id>` placeholders with links to other migrated pages.
+
+    Links are RELATIVE to the source page so they survive moving/renaming the
+    collective (the collective is inherited from the current page's URL). The one
+    exception is the collective root/landing page (source_route == []): its URL
+    has no trailing path segment to be relative to, so its links fall back to the
+    absolute '/apps/collectives/<segment>/...' form.
+    """
+    root_source = not source_route
+
     def _sub(m):
-        url = link_map.get(m.group(1))
-        return (url + (m.group(2) or "")) if url else m.group(0)
+        target_route = page_routes.get(m.group(1))
+        if target_route is None:
+            return m.group(0)  # target not migrated — leave the placeholder's link alone
+        anchor = m.group(2) or ""
+        if root_source:
+            href = "/apps/collectives/" + "/".join(
+                quote(s) for s in [collective_segment, *target_route])
+        else:
+            href = _relative_route_link(target_route, source_route)
+        return href + anchor
+
     return CPAGE_LINK_RE.sub(_sub, content)
 
 
@@ -1314,7 +1342,9 @@ def convert(exclude_images, exclude_attachments, dry_run, debug, log_file):
 
 @cli.command()
 @add_options(COMMON_OPTIONS)
-@click.option("--target-parent", default="MigratedPages", help="Parent page in Collectives.")
+@click.option("--target-parent", default="MigratedPages",
+              help="Top folder in the collective. Use '' to import at the collective "
+                   "base (the space homepage becomes the landing page).")
 def upload(target_parent, dry_run, debug, log_file):
     """Upload converted files to Nextcloud Collectives."""
     setup_logging(debug, log_file)
@@ -1395,7 +1425,9 @@ def upload(target_parent, dry_run, debug, log_file):
             log.error("Failed to upload attachment %s: %s", remote_path, e)
 
     # Pass 2: Patch markdown with file-ID links + internal page links, then upload
-    page_link_map = build_page_link_map(state, target_parent, nc.collective_segment)
+    page_routes = build_page_routes(state, target_parent)
+    id_by_path = {Path(rec["convert_path"]): pid
+                  for pid, rec in state.pages.items() if rec.get("convert_path")}
     uploaded_pages = set()
     for local_file in md_files:
         relative = local_file.relative_to(convert_base)
@@ -1406,8 +1438,9 @@ def upload(target_parent, dry_run, debug, log_file):
         try:
             content = local_file.read_text(encoding="utf-8")
 
-            # Resolve internal page-link placeholders to Collectives page URLs
-            content = resolve_page_links(content, page_link_map)
+            # Resolve internal page-link placeholders (relative to this page)
+            source_route = page_routes.get(id_by_path.get(local_file), [])
+            content = resolve_page_links(content, source_route, page_routes, nc.collective_segment)
 
             # Replace attachment links with absolute Nextcloud file URLs
             dir_urls = attachment_urls.get(full_remote_dir, {})
@@ -1464,7 +1497,9 @@ def upload(target_parent, dry_run, debug, log_file):
 @add_options(COMMON_OPTIONS)
 @add_options(SCOPE_OPTIONS)
 @add_options(ATTACHMENT_OPTIONS)
-@click.option("--target-parent", default="MigratedPages", help="Parent page in Collectives.")
+@click.option("--target-parent", default="MigratedPages",
+              help="Top folder in the collective. Use '' to import at the collective "
+                   "base (the space homepage becomes the landing page).")
 def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
             target_parent, dry_run, debug, log_file):
     """Run full migration pipeline: export → convert → upload."""
@@ -1709,7 +1744,7 @@ def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
     nc.mkdir_p(target_parent)
 
     converted = state.get_pages_by_status("converted")
-    page_link_map = build_page_link_map(state, target_parent, nc.collective_segment)
+    page_routes = build_page_routes(state, target_parent)
     for pid, page_rec in converted.items():
         sk = page_rec.get("space_key", "default")
         convert_base = Path("convert_data") / sk
@@ -1728,8 +1763,9 @@ def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
             nc.mkdir_p(f"{target_parent}/{parent_dirs}")
 
         try:
-            # Resolve internal page-link placeholders, then upload patched content
-            content = resolve_page_links(convert_file.read_text(encoding="utf-8"), page_link_map)
+            # Resolve internal page-link placeholders (relative to this page)
+            content = resolve_page_links(convert_file.read_text(encoding="utf-8"),
+                                         page_routes.get(pid, []), page_routes, nc.collective_segment)
             with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False,
                                              encoding="utf-8") as tmp:
                 tmp.write(content)

--- a/migrate.py
+++ b/migrate.py
@@ -426,25 +426,14 @@ class Converter:
                     if parts:
                         cell.insert(0, " — ".join(parts))
 
-        # Info / warning / note panels → blockquotes
+        # Info / warning / note panels → blockquotes. No "Info:"/"Note:" label is
+        # prepended: Collectives renders the blockquote distinctly, and Confluence
+        # panel bodies frequently already start with their own label, so a prefix
+        # just duplicates it.
         for panel in soup.find_all("div", class_=re.compile(r"(confluence-information-macro)")):
-            macro_type = "Note"
-            classes = panel.get("class", [])
-            for cls in classes:
-                if "note" in cls:
-                    macro_type = "Note"
-                elif "warning" in cls:
-                    macro_type = "Warning"
-                elif "tip" in cls:
-                    macro_type = "Tip"
-                elif "info" in cls:
-                    macro_type = "Info"
             body = panel.find("div", class_="confluence-information-macro-body")
             if body:
                 bq = soup.new_tag("blockquote")
-                prefix = soup.new_tag("strong")
-                prefix.string = f"{macro_type}: "
-                bq.append(prefix)
                 for child in list(body.children):
                     bq.append(child.extract() if isinstance(child, Tag) else child)
                 panel.replace_with(bq)
@@ -1368,7 +1357,7 @@ def upload(target_parent, dry_run, debug, log_file):
                 def _replace_link(m):
                     label, href = m.group(1), m.group(2)
                     if href in dir_urls:
-                        return f"[{label}]({dir_urls[href]})"
+                        return f"- [{label}]({dir_urls[href]})"  # keep the list bullet
                     return m.group(0)
 
                 content = re.sub(

--- a/migrate.py
+++ b/migrate.py
@@ -745,9 +745,11 @@ class NextcloudClient:
         self.base_url = base_url.rstrip("/")
         self.username = username
         self.collective = collective
+        # URL segment for internal page links; slug-id form after resolution.
+        self.collective_segment = collective
         self.files_base = f"{self.base_url}/remote.php/dav/files/{username}"
-        # Default to the modern hidden folder; verify_connection() may switch to
-        # the legacy name if that is what the server actually exposes.
+        # Default to the modern hidden folder; resolution may switch it (incl.
+        # localised names like '.Kollektive').
         self.collectives_dir = self.COLLECTIVES_DIRS[0]
         self.session = requests.Session()
         self.session.auth = (username, password)
@@ -756,12 +758,73 @@ class NextcloudClient:
     def dav_base(self):
         return f"{self.files_base}/{self.collectives_dir}/{self.collective}"
 
-    def verify_connection(self):
-        """Verify we can reach the collective, auto-detecting the storage folder.
+    def _ocs_get(self, path):
+        return self.session.get(
+            f"{self.base_url}{path}",
+            headers={"OCS-APIRequest": "true", "Accept": "application/json"},
+        )
 
-        Tries ".Collectives/<name>" then "Collectives/<name>" so the tool works
-        against both modern and legacy Collectives without configuration.
+    def resolve_collective(self):
+        """Resolve the configured collective via the Collectives OCS API.
+
+        Matches the configured NEXTCLOUD_COLLECTIVE against each collective's
+        name, slug, or '<slug>-<id>'. On a match, sets the WebDAV folder name
+        (the display name), the storage folder read from a page's
+        `collectivePath` (so localised folders like '.Kollektive' work without
+        guessing), and the '<slug>-<id>' URL segment used for internal links.
+        Returns True on success, False if the API/match is unavailable.
         """
+        try:
+            resp = self._ocs_get("/ocs/v2.php/apps/collectives/api/v1.0/collectives")
+            if resp.status_code != 200:
+                return False
+            collectives = resp.json().get("ocs", {}).get("data", {}).get("collectives", [])
+        except Exception:
+            return False
+
+        match = next(
+            (c for c in collectives
+             if self.collective in (c.get("name"), c.get("slug"), f"{c.get('slug')}-{c.get('id')}")),
+            None,
+        )
+        if not match:
+            return False
+
+        cid = match["id"]
+        self.collective = match.get("name")               # WebDAV folder = display name
+        self.collective_segment = f"{match.get('slug')}-{cid}"
+        try:  # localised storage folder, read rather than guessed
+            pages = (self._ocs_get(
+                f"/ocs/v2.php/apps/collectives/api/v1.0/collectives/{cid}/pages")
+                .json().get("ocs", {}).get("data", {}).get("pages", []))
+            for p in pages:
+                cp = p.get("collectivePath")
+                if cp and "/" in cp:
+                    self.collectives_dir = cp.split("/", 1)[0]
+                    break
+        except Exception:
+            pass
+        return True
+
+    def verify_connection(self):
+        """Verify we can reach the collective.
+
+        Prefers the Collectives OCS API (handles localised storage folders and
+        display-name vs slug). Falls back to probing '.Collectives'/'Collectives'
+        for older servers without the API.
+        """
+        if self.resolve_collective():
+            resp = self.session.request("PROPFIND", self.dav_base, headers={"Depth": "0"})
+            if resp.status_code == 401:
+                raise click.ClickException("Nextcloud authentication failed — check credentials.")
+            if resp.status_code in (200, 207):
+                log.info("Connected to Nextcloud collective: %s (under %s)",
+                         self.collective, self.collectives_dir)
+                return
+            raise click.ClickException(
+                f"Collective '{self.collective}' resolved but {self.dav_base} "
+                f"returned HTTP {resp.status_code}")
+
         last_status = None
         for candidate in self.COLLECTIVES_DIRS:
             self.collectives_dir = candidate
@@ -769,21 +832,16 @@ class NextcloudClient:
             if resp.status_code == 401:
                 raise click.ClickException("Nextcloud authentication failed — check credentials.")
             if resp.status_code in (200, 207):
-                log.info(
-                    "Connected to Nextcloud collective: %s (under %s)",
-                    self.collective, candidate,
-                )
+                log.info("Connected to Nextcloud collective: %s (under %s)",
+                         self.collective, candidate)
                 return
             last_status = resp.status_code
 
         if last_status == 404:
             raise click.ClickException(
-                f"Collective '{self.collective}' not found under "
-                f"{'/'.join(self.COLLECTIVES_DIRS)} for user {self.username}."
-            )
-        raise click.ClickException(
-            f"Nextcloud PROPFIND failed with status {last_status}"
-        )
+                f"Collective '{self.collective}' not found (no OCS match; probed "
+                f"{'/'.join(self.COLLECTIVES_DIRS)}) for user {self.username}.")
+        raise click.ClickException(f"Nextcloud PROPFIND failed with status {last_status}")
 
     @staticmethod
     def _remote(path):
@@ -1337,7 +1395,7 @@ def upload(target_parent, dry_run, debug, log_file):
             log.error("Failed to upload attachment %s: %s", remote_path, e)
 
     # Pass 2: Patch markdown with file-ID links + internal page links, then upload
-    page_link_map = build_page_link_map(state, target_parent, os.getenv("NEXTCLOUD_COLLECTIVE", ""))
+    page_link_map = build_page_link_map(state, target_parent, nc.collective_segment)
     uploaded_pages = set()
     for local_file in md_files:
         relative = local_file.relative_to(convert_base)
@@ -1651,7 +1709,7 @@ def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
     nc.mkdir_p(target_parent)
 
     converted = state.get_pages_by_status("converted")
-    page_link_map = build_page_link_map(state, target_parent, os.getenv("NEXTCLOUD_COLLECTIVE", ""))
+    page_link_map = build_page_link_map(state, target_parent, nc.collective_segment)
     for pid, page_rec in converted.items():
         sk = page_rec.get("space_key", "default")
         convert_base = Path("convert_data") / sk

--- a/migrate.py
+++ b/migrate.py
@@ -3,6 +3,7 @@
 
 __version__ = "0.6.0"
 
+import html
 import json
 import logging
 import os
@@ -224,6 +225,35 @@ class ConfluenceClient:
     def get_all_spaces(self):
         return list(self._paginate("/wiki/api/v2/spaces"))
 
+    # -- space templates --------------------------------------------------
+
+    def get_space_templates(self, space_key):
+        """List a space's page content-templates (Confluence v1 REST API).
+
+        Templates have no v2 endpoint, and the v1 listing is start/limit paged
+        (not cursor-based, so _paginate does not apply). Bodies come back in
+        STORAGE format via expand=body — there is no export_view for templates.
+        Blueprint-derived entries (templateType != "page") cannot be recreated
+        as plain content and are skipped.
+        """
+        out, start, limit = [], 0, 25
+        while True:
+            data = self._get_json(
+                "/wiki/rest/api/template/page",
+                spaceKey=space_key, expand="body,labels", start=start, limit=limit,
+            )
+            batch = data.get("results", [])
+            out.extend(t for t in batch if t.get("templateType") == "page")
+            if len(batch) < limit:
+                break
+            start += limit
+        return out
+
+    def get_template(self, template_id):
+        """Fetch a single template by id (body included by default). Fallback
+        for the rare list entry that arrives without an expanded body."""
+        return self._get_json(f"/wiki/rest/api/template/{template_id}")
+
     # -- pages ------------------------------------------------------------
 
     def get_space_pages(self, space_id):
@@ -332,6 +362,14 @@ class Converter:
     #   /wiki/spaces/TEAM/pages/67890/Other+Page
     #   https://x.atlassian.net/wiki/spaces/TEAM/pages/67890
     PAGE_LINK_RE = re.compile(r"/pages/(\d+)")
+
+    # Template-variable tags appear ONLY in storage-format template bodies (never
+    # in export_view pages). <at:declarations> defines the variables; inline
+    # <at:var at:name="X"/> references them. These are XHTML/non-HTML tags that
+    # html.parser mishandles, so they are dealt with by a regex pre-pass on the
+    # raw storage XHTML before BeautifulSoup ever sees it.
+    AT_DECLARATIONS_RE = re.compile(r"<at:declarations>.*?</at:declarations>", re.S)
+    AT_VAR_RE = re.compile(r'<at:var\b[^>]*?at:name="([^"]*)"[^>]*?>(?:\s*</at:var>)?', re.S)
 
     def __init__(self, exclude_images=False, exclude_attachments=False):
         self.exclude_images = exclude_images
@@ -592,6 +630,43 @@ class Converter:
 
         return md
 
+    def _substitute_template_variables(self, body_html):
+        """Render Confluence template variables for Collectives (which has no
+        variable concept): drop the <at:declarations> metadata block and turn
+        each inline <at:var at:name="X"/> into the Markdown placeholder {{X}}."""
+        body_html = self.AT_DECLARATIONS_RE.sub("", body_html)
+        return self.AT_VAR_RE.sub(lambda m: "{{" + html.unescape(m.group(1)) + "}}", body_html)
+
+    # An unsupported-macro HTML comment left by preprocess_html (matched so a
+    # template can surface it as visible text instead of letting html2text drop it).
+    UNSUPPORTED_MACRO_COMMENT_RE = re.compile(r"<!--\s*Unsupported macro:\s*(.*?)\s*-->")
+
+    def convert_template(self, template_data):
+        """Convert one Confluence space page-template (storage XHTML) to Markdown.
+
+        Templates have no attachments, comments, or children, so this is just
+        variable-substitution → preprocess_html → html2text — no link map and
+        none of convert_page's appended ## Comments / ## Attachments sections.
+
+        Storage-format templates are full of unexpanded <ac:structured-macro>
+        elements (no rendered preview, unlike export_view pages). preprocess_html
+        turns each into an "<!-- Unsupported macro: NAME -->" comment, which
+        html2text would then silently strip. Since macros are common in templates,
+        we surface each as a visible "[Unsupported macro: NAME]" marker so the
+        author can re-add it. The macro BODY is still lost (a full storage-format
+        macro renderer is out of scope) — see the README/limitations.
+        """
+        body = template_data.get("body", {})
+        if isinstance(body, dict):
+            body_html = (body.get("storage", {}) or {}).get("value", "") or ""
+        else:
+            body_html = body or ""
+        body_html = self._substitute_template_variables(body_html)
+        processed = self.preprocess_html(body_html)
+        processed = self.UNSUPPORTED_MACRO_COMMENT_RE.sub(
+            r"<p>[Unsupported macro: \1]</p>", processed)
+        return self.html_to_markdown(processed)
+
     def format_comments(self, comments):
         """Format comments as a ## Comments section."""
         if not comments:
@@ -762,6 +837,14 @@ class NextcloudClient:
     # older versions used "Collectives". Probed in verify_connection().
     COLLECTIVES_DIRS = (".Collectives", "Collectives")
 
+    # Collectives (2.17.0+) keeps page-templates as ordinary pages inside a hidden
+    # ".templates" folder at the collective root — template-ness is purely folder
+    # location, with no DB flag. The folder needs an index page or Collectives
+    # won't list its contents; this marker is the documented index content.
+    TEMPLATES_DIR = ".templates"
+    TEMPLATES_INDEX = "Readme.md"
+    TEMPLATES_INDEX_CONTENT = "## This folder contains template files for the collective\n"
+
     def __init__(self, base_url, username, password, collective):
         self.base_url = base_url.rstrip("/")
         self.username = username
@@ -931,6 +1014,33 @@ class NextcloudClient:
         url = f"{self.dav_base}/{self._remote(path).lstrip('/')}"
         resp = self.session.request("PROPFIND", url, headers={"Depth": "0"})
         return resp.status_code in (200, 207)
+
+    def upload_text(self, remote_path, text, content_type="text/markdown; charset=utf-8"):
+        """PUT in-memory text to a path under the collective root (no temp file)."""
+        remote_path = self._remote(remote_path)
+        url = f"{self.dav_base}/{remote_path.lstrip('/')}"
+        resp = self.session.put(url, data=text.encode("utf-8"),
+                                headers={"Content-Type": content_type})
+        if resp.status_code not in (200, 201, 204):
+            raise click.ClickException(
+                f"Upload failed for {remote_path}: HTTP {resp.status_code}"
+            )
+        log.debug("Uploaded: %s", remote_path)
+
+    def ensure_templates_folder(self):
+        """Create the hidden .templates/ folder at the collective root and seed
+        its required index page if missing. Idempotent (MKCOL tolerates 405)."""
+        self.mkdir_p(self.TEMPLATES_DIR)
+        index = f"{self.TEMPLATES_DIR}/{self.TEMPLATES_INDEX}"
+        if not self.exists(index):
+            self.upload_text(index, self.TEMPLATES_INDEX_CONTENT)
+
+    def upload_template(self, title, markdown):
+        """Write one template as .templates/<title>.md (title pre-sanitized by
+        the caller). Overwrites by path, so re-runs update in place."""
+        remote_path = f"{self.TEMPLATES_DIR}/{title}.md"
+        self.upload_text(remote_path, markdown)
+        return remote_path
 
 
 # ---------------------------------------------------------------------------
@@ -1521,8 +1631,11 @@ def upload(target_parent, dry_run, debug, log_file):
 @click.option("--target-parent", default="MigratedPages",
               help="Top folder in the collective. Use '' to import at the collective "
                    "base (the space homepage becomes the landing page).")
+@click.option("--include-templates", is_flag=True,
+              help="Also import the space's page-templates into the collective's "
+                   ".templates/ folder (requires --space).")
 def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
-            target_parent, dry_run, debug, log_file):
+            target_parent, include_templates, dry_run, debug, log_file):
     """Run full migration pipeline: export → convert → upload."""
     setup_logging(debug, log_file)
 
@@ -1816,6 +1929,17 @@ def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
             page_rec["error"] = f"Upload failed: {e}"
             state.set_page(pid, page_rec)
 
+    # --- Templates (opt-in) ---
+    if include_templates:
+        if not space_key:
+            log.warning("--include-templates requires --space; skipping templates")
+        else:
+            click.echo("\n" + "=" * 60)
+            click.echo("Phase 4: Templates")
+            click.echo("=" * 60)
+            t_ok, t_fail = _run_template_import(conf_client, converter, nc, space_key, dry_run)
+            click.echo(f"Templates: {t_ok} ok, {t_fail} failed")
+
     # Final summary
     summary = state.summary()
     click.echo("\n" + "=" * 60)
@@ -1861,6 +1985,94 @@ def status(dry_run, debug, log_file):
             click.echo(f"  [{pid}] {p['title']}: {p.get('error', 'unknown error')}")
 
     sys.exit(EXIT_SUCCESS)
+
+
+# -- import-templates -----------------------------------------------------
+
+
+def _run_template_import(conf_client, converter, nc, space_key, dry_run):
+    """Fetch a space's page-templates, convert each, and upload them into the
+    collective's hidden .templates/ folder. Returns (ok, fail) counts.
+
+    Shared by the standalone `import-templates` command and `migrate
+    --include-templates`. Per-template failures are logged and counted; they do
+    not abort the run.
+    """
+    templates = conf_client.get_space_templates(space_key)
+    log.info("Found %d page template(s) in space %s", len(templates), space_key)
+
+    if dry_run:
+        click.echo(f"\n[DRY RUN] {len(templates)} template(s) → .templates/")
+        for t in templates:
+            click.echo(f"  Template: {t.get('name', '?')} (ID: {t.get('templateId')})")
+        return (0, 0)
+
+    nc.ensure_templates_folder()
+    existing, ok, fail = set(), 0, 0
+    for t in templates:
+        name = t.get("name", "untitled")
+        title = converter.sanitize_filename(name, existing)
+        existing.add(title)
+        try:
+            md = converter.convert_template(t)
+            remote = nc.upload_template(title, md)
+            log.info("Uploaded template: %s → %s", name, remote)
+            ok += 1
+        except Exception as e:
+            log.error("Failed to import template '%s': %s", name, e)
+            fail += 1
+    return (ok, fail)
+
+
+@cli.command(name="import-templates")
+@click.option("--space", "space_key", required=True, help="Confluence space key.")
+@add_options(COMMON_OPTIONS)
+def import_templates(space_key, dry_run, debug, log_file):
+    """Import a Confluence space's page-templates as Collectives page templates."""
+    setup_logging(debug, log_file)
+    require_env("CONFLUENCE_BASE_URL", "CONFLUENCE_USERNAME", "CONFLUENCE_API_TOKEN")
+    if not dry_run:
+        require_env("NEXTCLOUD_URL", "NEXTCLOUD_USERNAME",
+                    "NEXTCLOUD_PASSWORD", "NEXTCLOUD_COLLECTIVE")
+
+    conf_client = ConfluenceClient(
+        os.getenv("CONFLUENCE_BASE_URL"),
+        os.getenv("CONFLUENCE_USERNAME"),
+        os.getenv("CONFLUENCE_API_TOKEN"),
+    )
+    try:
+        conf_client.verify_auth()
+    except click.ClickException:
+        sys.exit(EXIT_AUTH)
+    except Exception as e:
+        log.error("Authentication failed: %s", e)
+        sys.exit(EXIT_AUTH)
+
+    converter = Converter()
+
+    nc = None
+    if not dry_run:
+        nc = NextcloudClient(
+            os.getenv("NEXTCLOUD_URL"),
+            os.getenv("NEXTCLOUD_USERNAME"),
+            os.getenv("NEXTCLOUD_PASSWORD"),
+            os.getenv("NEXTCLOUD_COLLECTIVE"),
+        )
+        try:
+            nc.verify_connection()
+        except click.ClickException:
+            raise
+        except Exception as e:
+            raise click.ClickException(f"Nextcloud connection failed: {e}")
+
+    ok, fail = _run_template_import(conf_client, converter, nc, space_key, dry_run)
+
+    click.echo("\n" + "=" * 60)
+    click.echo(f"Templates imported: {ok} ok, {fail} failed")
+    click.echo("=" * 60)
+    if dry_run or fail == 0:
+        sys.exit(EXIT_SUCCESS)
+    sys.exit(EXIT_FAILURE if ok == 0 else EXIT_PARTIAL)
 
 
 # ---------------------------------------------------------------------------

--- a/migrate.py
+++ b/migrate.py
@@ -371,9 +371,14 @@ class Converter:
     AT_DECLARATIONS_RE = re.compile(r"<at:declarations>.*?</at:declarations>", re.S)
     AT_VAR_RE = re.compile(r'<at:var\b[^>]*?at:name="([^"]*)"[^>]*?>(?:\s*</at:var>)?', re.S)
 
-    def __init__(self, exclude_images=False, exclude_attachments=False):
+    def __init__(self, exclude_images=False, exclude_attachments=False,
+                 exclude_details=False):
         self.exclude_images = exclude_images
         self.exclude_attachments = exclude_attachments
+        # Confluence "details" (page-properties) macro handling. Default: extract
+        # the inner table so its content survives. When True, drop the macro and
+        # its body entirely (used where the properties box is unwanted).
+        self.exclude_details = exclude_details
         # page_id -> output path relative to the space root (e.g. "Section/Leaf.md").
         # Populated via set_link_map() so internal page links can be rewritten to
         # relative links between the migrated Markdown files.
@@ -492,6 +497,11 @@ class Converter:
                 new_pre.append(code_tag)
                 code_macro.replace_with(new_pre)
 
+        # Details (page-properties) macro: extract its inner table so the content
+        # survives (or drop it entirely when exclude_details). Runs before the
+        # generic handler below, else it degrades to an "Unsupported macro" marker.
+        self._handle_details_macros(soup)
+
         # ac:structured-macro and data-macro-name → HTML comments, BUT keep any
         # rendered image inside (draw.io / Gliffy / etc. embed a PNG preview in
         # export_view) so diagrams still show up in Collectives.
@@ -558,6 +568,21 @@ class Converter:
             code = soup.new_tag("code")
             code.string = text
             span.replace_with(code)
+
+    def _handle_details_macros(self, soup):
+        """Confluence "details" (page-properties) macros wrap a properties table in
+        an <ac:rich-text-body>. By default, unwrap that table so its content
+        survives (the generic macro handler would otherwise drop it to a marker).
+        When exclude_details is set, remove the macro and its body entirely."""
+        for macro in soup.find_all("ac:structured-macro"):
+            if macro.get("ac:name") != "details":
+                continue
+            body = macro.find("ac:rich-text-body")
+            if self.exclude_details or not body:
+                macro.decompose()
+            else:
+                macro.replace_with(body)   # promote the table out of the macro
+                body.unwrap()              # drop the rich-text-body wrapper
 
     def _replace_unsupported_macro(self, soup, macro, name):
         """Drop an unsupported macro, but lift out any rendered <img> it wraps.

--- a/migrate.py
+++ b/migrate.py
@@ -529,24 +529,22 @@ class Converter:
             macro.replace_with(Comment(f" Unsupported macro: {name} "))
 
     def _rewrite_internal_links(self, soup, current_path):
-        """Rewrite <a> links targeting migrated Confluence pages to relative
-        links between the output Markdown files. Links to pages outside the
-        migrated set (or non-page links) are left untouched."""
-        current_dir = posixpath.dirname(current_path)
+        """Mark <a> links that target a migrated Confluence page with a
+        `cpage:<id>` placeholder. The placeholder is resolved to a real
+        Collectives page URL at upload time (`resolve_page_links`), because the
+        URL depends on the upload target parent and collective name, which the
+        converter does not know. Links to pages outside the migrated set (or
+        non-page links) are left untouched."""
         for a in soup.find_all("a", href=True):
             href = a["href"]
             m = self.PAGE_LINK_RE.search(href)
             if not m:
                 continue
-            target_path = self.page_link_map.get(m.group(1))
-            if not target_path:
+            target_id = m.group(1)
+            if target_id not in self.page_link_map:
                 continue  # target page not part of this migration — leave as-is
-            anchor = ""
-            if "#" in href:
-                anchor = "#" + href.split("#", 1)[1]
-            rel = posixpath.relpath(target_path, current_dir or ".")
-            rel = "/".join(quote(seg) for seg in rel.split("/"))
-            a["href"] = rel + anchor
+            anchor = "#" + href.split("#", 1)[1] if "#" in href else ""
+            a["href"] = f"cpage:{target_id}{anchor}"
 
     # -- conversion -------------------------------------------------------
 
@@ -854,10 +852,11 @@ class NextcloudClient:
         log.warning("Could not get file ID for %s (HTTP %d)", remote_path, resp.status_code)
         return None
 
-    def file_url(self, file_id, remote_dir):
-        """Build a Nextcloud Files app URL for the given file ID."""
-        dir_path = f"/Collectives/{self.collective}/{remote_dir.lstrip('/')}"
-        return f"{self.base_url}/apps/files/files/{file_id}?dir={quote(dir_path)}&openfile=true"
+    def file_url(self, file_id, remote_dir=None):
+        """Nextcloud "open file by id" URL. Resolves regardless of where the file
+        lives — important because collectives live under the hidden .Collectives
+        folder, which a path-based Files URL (dir=...) cannot navigate into."""
+        return f"{self.base_url}/f/{file_id}"
 
     def exists(self, path):
         """Check if a remote path exists via PROPFIND depth 0."""
@@ -878,6 +877,56 @@ def require_env(*keys):
         raise click.ClickException(
             f"Missing required environment variables: {', '.join(missing)}"
         )
+
+
+# Placeholder emitted by the converter for an internal page link; resolved here.
+CPAGE_LINK_RE = re.compile(r"cpage:(\d+)(#[^)>\s]*)?")
+
+
+def page_route_segments(output_rel_path):
+    """Collectives route segments (page titles) for a converted page file path,
+    relative to the space root. A page's title in Collectives is its file/folder
+    name, so the route is the path with the `.md` stripped and the `Readme.md`
+    of a parent page collapsed to its folder.
+
+    e.g. "Drafts/Proc/CAPA.md" -> ["Drafts", "Proc", "CAPA"]
+         "Drafts/Proc/Readme.md" -> ["Drafts", "Proc"]   (parent/folder page)
+         "Readme.md" -> []                                (space homepage)
+    """
+    p = output_rel_path.replace("\\", "/")
+    if p == "Readme.md":
+        return []
+    if p.endswith("/Readme.md"):
+        p = p[: -len("/Readme.md")]
+    elif p.endswith(".md"):
+        p = p[:-3]
+    return [seg for seg in p.split("/") if seg]
+
+
+def build_page_link_map(state, target_parent, collective):
+    """Map Confluence page_id -> absolute Collectives page URL, for resolving
+    `cpage:` placeholders. Collectives resolves internal links by walking the
+    page-title path under the collective, so the URL is
+    /apps/collectives/<collective>/<target_parent>/<title path>.
+    """
+    link_map = {}
+    for pid, rec in state.pages.items():
+        convert_path = rec.get("convert_path")
+        if not convert_path:
+            continue
+        space_key = rec.get("space_key", "default")
+        rel = Path(convert_path).relative_to(Path("convert_data") / space_key).as_posix()
+        segments = [collective, target_parent, *page_route_segments(rel)]
+        link_map[pid] = "/apps/collectives/" + "/".join(quote(s) for s in segments)
+    return link_map
+
+
+def resolve_page_links(content, link_map):
+    """Replace `cpage:<id>` placeholders in Markdown with real Collectives URLs."""
+    def _sub(m):
+        url = link_map.get(m.group(1))
+        return (url + (m.group(2) or "")) if url else m.group(0)
+    return CPAGE_LINK_RE.sub(_sub, content)
 
 
 def determine_exit_code(state):
@@ -1298,7 +1347,8 @@ def upload(target_parent, dry_run, debug, log_file):
         except Exception as e:
             log.error("Failed to upload attachment %s: %s", remote_path, e)
 
-    # Pass 2: Patch markdown with file-ID links, then upload
+    # Pass 2: Patch markdown with file-ID links + internal page links, then upload
+    page_link_map = build_page_link_map(state, target_parent, os.getenv("NEXTCLOUD_COLLECTIVE", ""))
     uploaded_pages = set()
     for local_file in md_files:
         relative = local_file.relative_to(convert_base)
@@ -1308,6 +1358,9 @@ def upload(target_parent, dry_run, debug, log_file):
 
         try:
             content = local_file.read_text(encoding="utf-8")
+
+            # Resolve internal page-link placeholders to Collectives page URLs
+            content = resolve_page_links(content, page_link_map)
 
             # Replace attachment links with absolute Nextcloud file URLs
             dir_urls = attachment_urls.get(full_remote_dir, {})
@@ -1609,6 +1662,7 @@ def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
     nc.mkdir_p(target_parent)
 
     converted = state.get_pages_by_status("converted")
+    page_link_map = build_page_link_map(state, target_parent, os.getenv("NEXTCLOUD_COLLECTIVE", ""))
     for pid, page_rec in converted.items():
         sk = page_rec.get("space_key", "default")
         convert_base = Path("convert_data") / sk
@@ -1627,7 +1681,16 @@ def migrate(space_key, pages, all_spaces, exclude_images, exclude_attachments,
             nc.mkdir_p(f"{target_parent}/{parent_dirs}")
 
         try:
-            nc.upload_file(str(convert_file), remote_path)
+            # Resolve internal page-link placeholders, then upload patched content
+            content = resolve_page_links(convert_file.read_text(encoding="utf-8"), page_link_map)
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False,
+                                             encoding="utf-8") as tmp:
+                tmp.write(content)
+                tmp_path = tmp.name
+            try:
+                nc.upload_file(tmp_path, remote_path)
+            finally:
+                os.unlink(tmp_path)
 
             # Also upload attachments in the same directory
             output_dir = convert_file.parent

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,35 @@ def sample_page_data(sample_page_html, sample_comments):
 
 
 @pytest.fixture
+def sample_template():
+    """A Confluence v1 space page-template (storage body with a template variable,
+    an <at:declarations> block, and an unexpanded macro)."""
+    return {
+        "templateId": "987654321",
+        "name": "Risk Assessment",
+        "templateType": "page",
+        "editorVersion": "v2",
+        "labels": [],
+        "space": {"key": "TEAM"},
+        "body": {
+            "storage": {
+                "value": (
+                    "<at:declarations>"
+                    '<at:string at:name="Risk Owner" />'
+                    "</at:declarations>"
+                    "<h2>Risk Assessment</h2>"
+                    '<p>Owner: <at:var at:name="Risk Owner" /></p>'
+                    '<ac:structured-macro ac:name="info">'
+                    "<ac:rich-text-body><p>Fill this in.</p></ac:rich-text-body>"
+                    "</ac:structured-macro>"
+                ),
+                "representation": "storage",
+            }
+        },
+    }
+
+
+@pytest.fixture
 def mock_confluence_response():
     """Factory for mock Confluence API responses."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,6 +48,13 @@ class TestHelp:
         assert result.exit_code == 0
         assert "--space" in result.output
         assert "--target-parent" in result.output
+        assert "--include-templates" in result.output
+
+    def test_import_templates_help(self, runner):
+        result = runner.invoke(cli, ["import-templates", "--help"])
+        assert result.exit_code == 0
+        assert "page-templates" in result.output
+        assert "--space" in result.output
 
     def test_version(self, runner):
         result = runner.invoke(cli, ["--version"])
@@ -106,3 +113,26 @@ class TestDryRun:
         with patch("migrate.STATE_FILE", str(tmp_path / ".migration-state.json")):
             result = runner.invoke(cli, ["status"])
             assert "No migration state" in result.output
+
+
+class TestImportTemplatesCLI:
+    def test_space_required(self, runner):
+        result = runner.invoke(cli, ["import-templates"])
+        assert result.exit_code != 0
+
+    def test_dry_run_lists_without_nextcloud(self, runner):
+        """--dry-run needs only Confluence creds and never touches Nextcloud."""
+        env = {
+            "CONFLUENCE_BASE_URL": "https://test.atlassian.net",
+            "CONFLUENCE_USERNAME": "user",
+            "CONFLUENCE_API_TOKEN": "token",
+        }
+        templates = [{"templateId": "1", "name": "Risk Assessment", "templateType": "page"}]
+        with patch.dict(os.environ, env, clear=False), \
+             patch("migrate.ConfluenceClient.verify_auth"), \
+             patch("migrate.ConfluenceClient.get_space_templates", return_value=templates), \
+             patch("migrate.NextcloudClient") as mock_nc:
+            result = runner.invoke(cli, ["import-templates", "--space", "TEAM", "--dry-run"])
+            assert result.exit_code == 0
+            assert "Risk Assessment" in result.output
+            mock_nc.assert_not_called()

--- a/tests/test_confluence_client.py
+++ b/tests/test_confluence_client.py
@@ -162,3 +162,45 @@ class TestSpaceResolution:
         with patch.object(client.session, "request", return_value=mock_resp):
             with pytest.raises(click.ClickException, match="not found"):
                 client.get_space_by_key("NOPE")
+
+
+class TestGetSpaceTemplates:
+    @staticmethod
+    def _resp(results):
+        r = MagicMock()
+        r.status_code = 200
+        r.json.return_value = {"results": results}
+        r.raise_for_status = MagicMock()
+        return r
+
+    def test_paginates_start_limit(self, client):
+        page1 = [{"templateId": str(i), "name": f"T{i}", "templateType": "page"}
+                 for i in range(25)]
+        page2 = [{"templateId": str(i), "name": f"T{i}", "templateType": "page"}
+                 for i in range(25, 28)]
+        with patch.object(client.session, "request",
+                          side_effect=[self._resp(page1), self._resp(page2)]) as mock_req:
+            out = client.get_space_templates("TEAM")
+            assert len(out) == 28
+            assert mock_req.call_count == 2
+            # second request advanced the start offset by the page size
+            assert mock_req.call_args_list[1].kwargs["params"]["start"] == 25
+
+    def test_filters_blueprint_templates(self, client):
+        results = [
+            {"templateId": "1", "name": "Page T", "templateType": "page"},
+            {"templateId": "2", "name": "Blueprint T", "templateType": "blueprint"},
+        ]
+        with patch.object(client.session, "request", side_effect=[self._resp(results)]):
+            out = client.get_space_templates("TEAM")
+            assert [t["templateId"] for t in out] == ["1"]
+
+    def test_passes_space_key_and_expand(self, client):
+        with patch.object(client.session, "request",
+                          side_effect=[self._resp([])]) as mock_req:
+            client.get_space_templates("TEAM")
+            params = mock_req.call_args_list[0].kwargs["params"]
+            assert params["spaceKey"] == "TEAM"
+            assert params["expand"] == "body,labels"
+            url = mock_req.call_args_list[0][0][1]
+            assert url.endswith("/wiki/rest/api/template/page")

--- a/tests/test_confluence_client.py
+++ b/tests/test_confluence_client.py
@@ -108,28 +108,36 @@ class TestRateLimiting:
 
 
 class TestDownloadURL:
-    def test_prepend_wiki_to_relative_download(self, client):
+    def test_uses_rest_child_attachment_route(self, client):
+        """Primary download must use the REST content/child/attachment route,
+        which honours API-token Basic auth (the legacy /wiki/download servlet
+        rejects API tokens with HTTP 401)."""
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.content = b"file-data"
         mock_resp.raise_for_status = MagicMock()
 
         with patch.object(client.session, "request", return_value=mock_resp) as mock_req:
-            client.download_attachment("/download/attachments/123/file.png")
-            # Should have prepended /wiki
+            data = client.download_attachment("123", "att999", fallback_url="/download/attachments/123/file.png")
+            assert data == b"file-data"
             call_url = mock_req.call_args[0][1]
-            assert call_url.startswith("https://test.atlassian.net/wiki/download/")
+            assert call_url.endswith("/wiki/rest/api/content/123/child/attachment/att999/download")
 
-    def test_absolute_url_unchanged(self, client):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.content = b"file-data"
-        mock_resp.raise_for_status = MagicMock()
+    def test_falls_back_to_download_link_on_error(self, client):
+        import requests
 
-        with patch.object(client.session, "request", return_value=mock_resp) as mock_req:
-            client.download_attachment("https://cdn.example.com/file.png")
-            call_url = mock_req.call_args[0][1]
-            assert call_url == "https://cdn.example.com/file.png"
+        ok = MagicMock(status_code=200, content=b"img", raise_for_status=MagicMock())
+
+        def side_effect(method, url, **kwargs):
+            if "/child/attachment/" in url:
+                raise requests.HTTPError("404")
+            return ok
+
+        with patch.object(client.session, "request", side_effect=side_effect) as mock_req:
+            data = client.download_attachment("123", "att999", fallback_url="/download/attachments/123/file.png")
+            assert data == b"img"
+            # fallback prepends /wiki to the servlet link
+            assert mock_req.call_args[0][1].startswith("https://test.atlassian.net/wiki/download/")
 
 
 class TestSpaceResolution:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -190,6 +190,90 @@ class TestHtmlToMarkdown:
         assert len(lines) == 1
 
 
+class TestPreserveDiagramImages:
+    """draw.io / Gliffy etc. render a PNG preview inside the macro in
+    export_view; that image must survive instead of being dropped."""
+
+    def test_drawio_image_preserved(self, converter):
+        html = (
+            '<div data-macro-name="drawio">'
+            '<img src="/download/attachments/12345/architecture.png?version=2" />'
+            '</div>'
+        )
+        result = converter.preprocess_html(html)
+        assert 'src="architecture.png"' in result
+        assert "Unsupported macro" not in result
+
+    def test_structured_macro_image_preserved(self, converter):
+        html = (
+            '<ac:structured-macro ac:name="drawio">'
+            '<img src="/download/attachments/1/flow.png" />'
+            '</ac:structured-macro>'
+        )
+        result = converter.preprocess_html(html)
+        assert 'src="flow.png"' in result
+        assert "Unsupported macro" not in result
+
+    def test_macro_without_image_still_becomes_comment(self, converter):
+        html = '<div data-macro-name="drawio"><p>diagram</p></div>'
+        result = converter.preprocess_html(html)
+        assert "Unsupported macro: drawio" in result
+
+
+class TestRewriteInternalLinks:
+    LINK_MAP = {
+        "67890": "Section/Other Page.md",
+        "111": "Readme.md",
+    }
+
+    def test_link_rewritten_relative_from_root(self, converter):
+        converter.set_link_map(self.LINK_MAP)
+        html = '<p>See <a href="/wiki/spaces/TEAM/pages/67890/Other+Page">Other Page</a></p>'
+        result = converter.preprocess_html(html, current_path="Readme.md")
+        # From root, target Section/Other Page.md -> "Section/Other%20Page.md"
+        assert 'href="Section/Other%20Page.md"' in result
+
+    def test_link_rewritten_relative_between_subdirs(self, converter):
+        converter.set_link_map(self.LINK_MAP)
+        html = '<a href="/wiki/spaces/TEAM/pages/111/Home">Home</a>'
+        result = converter.preprocess_html(html, current_path="Section/Leaf.md")
+        # From Section/, target Readme.md at root -> "../Readme.md"
+        assert 'href="../Readme.md"' in result
+
+    def test_anchor_preserved(self, converter):
+        converter.set_link_map(self.LINK_MAP)
+        html = '<a href="/wiki/spaces/TEAM/pages/67890/Other+Page#Heading">x</a>'
+        result = converter.preprocess_html(html, current_path="Readme.md")
+        assert 'href="Section/Other%20Page.md#Heading"' in result
+
+    def test_link_to_unmigrated_page_untouched(self, converter):
+        converter.set_link_map(self.LINK_MAP)
+        html = '<a href="/wiki/spaces/TEAM/pages/99999/Gone">x</a>'
+        result = converter.preprocess_html(html, current_path="Readme.md")
+        assert "/wiki/spaces/TEAM/pages/99999/Gone" in result
+
+    def test_external_link_untouched(self, converter):
+        converter.set_link_map(self.LINK_MAP)
+        html = '<a href="https://example.com/page">x</a>'
+        result = converter.preprocess_html(html, current_path="Readme.md")
+        assert 'href="https://example.com/page"' in result
+
+    def test_no_rewrite_without_link_map(self, converter):
+        html = '<a href="/wiki/spaces/TEAM/pages/67890/Other+Page">x</a>'
+        result = converter.preprocess_html(html, current_path="Readme.md")
+        assert "/wiki/spaces/TEAM/pages/67890" in result
+
+    def test_convert_page_rewrites_via_current_page_id(self, converter):
+        converter.set_link_map({"1": "Readme.md", "67890": "Section/Other Page.md"})
+        page_data = {
+            "body": '<a href="/wiki/spaces/TEAM/pages/67890/Other+Page">Other</a>',
+            "comments": [],
+            "attachments": [],
+        }
+        md = converter.convert_page(page_data, current_page_id="1")
+        assert "Section/Other%20Page.md" in md
+
+
 class TestConvertPage:
     def test_full_page_conversion(self, converter, sample_page_data):
         md = converter.convert_page(sample_page_data)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -669,3 +669,23 @@ class TestTemplateConversion:
     def test_convert_template_empty_body(self, converter):
         assert converter.convert_template({}) == ""
         assert converter.convert_template({"body": {}}) == ""
+
+    def test_details_macro_table_extracted(self, converter):
+        """The details (page-properties) macro's inner table is preserved (default)."""
+        det = ('<ac:structured-macro ac:name="details"><ac:rich-text-body>'
+               '<table><tr><th>Verantwortlicher</th><td>Max</td></tr></table>'
+               '</ac:rich-text-body></ac:structured-macro>')
+        md = converter.convert_template({"body": {"storage": {"value": det}}})
+        assert "Verantwortlicher" in md and "Max" in md
+        assert "Unsupported macro: details" not in md
+        assert "<ac:" not in md
+
+    def test_details_macro_excluded_when_flagged(self):
+        """exclude_details drops the macro and its table entirely."""
+        c = Converter(exclude_details=True)
+        det = ('<ac:structured-macro ac:name="details"><ac:rich-text-body>'
+               '<table><tr><th>Verantwortlicher</th><td>Max</td></tr></table>'
+               '</ac:rich-text-body></ac:structured-macro>')
+        md = c.convert_template({"body": {"storage": {"value": det}}})
+        assert "Verantwortlicher" not in md
+        assert "Unsupported macro: details" not in md

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -226,31 +226,24 @@ class TestRewriteInternalLinks:
         "111": "Readme.md",
     }
 
-    def test_link_rewritten_relative_from_root(self, converter):
+    def test_link_to_migrated_page_becomes_placeholder(self, converter):
         converter.set_link_map(self.LINK_MAP)
         html = '<p>See <a href="/wiki/spaces/TEAM/pages/67890/Other+Page">Other Page</a></p>'
         result = converter.preprocess_html(html, current_path="Readme.md")
-        # From root, target Section/Other Page.md -> "Section/Other%20Page.md"
-        assert 'href="Section/Other%20Page.md"' in result
+        assert 'href="cpage:67890"' in result
 
-    def test_link_rewritten_relative_between_subdirs(self, converter):
-        converter.set_link_map(self.LINK_MAP)
-        html = '<a href="/wiki/spaces/TEAM/pages/111/Home">Home</a>'
-        result = converter.preprocess_html(html, current_path="Section/Leaf.md")
-        # From Section/, target Readme.md at root -> "../Readme.md"
-        assert 'href="../Readme.md"' in result
-
-    def test_anchor_preserved(self, converter):
+    def test_anchor_preserved_in_placeholder(self, converter):
         converter.set_link_map(self.LINK_MAP)
         html = '<a href="/wiki/spaces/TEAM/pages/67890/Other+Page#Heading">x</a>'
         result = converter.preprocess_html(html, current_path="Readme.md")
-        assert 'href="Section/Other%20Page.md#Heading"' in result
+        assert 'href="cpage:67890#Heading"' in result
 
     def test_link_to_unmigrated_page_untouched(self, converter):
         converter.set_link_map(self.LINK_MAP)
         html = '<a href="/wiki/spaces/TEAM/pages/99999/Gone">x</a>'
         result = converter.preprocess_html(html, current_path="Readme.md")
         assert "/wiki/spaces/TEAM/pages/99999/Gone" in result
+        assert "cpage:" not in result
 
     def test_external_link_untouched(self, converter):
         converter.set_link_map(self.LINK_MAP)
@@ -262,8 +255,9 @@ class TestRewriteInternalLinks:
         html = '<a href="/wiki/spaces/TEAM/pages/67890/Other+Page">x</a>'
         result = converter.preprocess_html(html, current_path="Readme.md")
         assert "/wiki/spaces/TEAM/pages/67890" in result
+        assert "cpage:" not in result
 
-    def test_convert_page_rewrites_via_current_page_id(self, converter):
+    def test_convert_page_emits_placeholder_via_current_page_id(self, converter):
         converter.set_link_map({"1": "Readme.md", "67890": "Section/Other Page.md"})
         page_data = {
             "body": '<a href="/wiki/spaces/TEAM/pages/67890/Other+Page">Other</a>',
@@ -271,7 +265,33 @@ class TestRewriteInternalLinks:
             "attachments": [],
         }
         md = converter.convert_page(page_data, current_page_id="1")
-        assert "Section/Other%20Page.md" in md
+        assert "cpage:67890" in md
+
+
+class TestResolvePageLinks:
+    def test_route_segments(self):
+        from migrate import page_route_segments
+        assert page_route_segments("Drafts/Proc/CAPA.md") == ["Drafts", "Proc", "CAPA"]
+        assert page_route_segments("Drafts/Proc/Readme.md") == ["Drafts", "Proc"]
+        assert page_route_segments("Readme.md") == []
+
+    def test_build_map_and_resolve(self, tmp_path):
+        from migrate import MigrationState, build_page_link_map, resolve_page_links
+        state = MigrationState(path=tmp_path / ".migration-state.json")
+        state.set_page("67890", {
+            "page_id": "67890", "space_key": "TEAM", "status": "converted",
+            "convert_path": str(Path("convert_data/TEAM/Section/Other Page.md")),
+        })
+        link_map = build_page_link_map(state, "MigratedPages", "My Collective")
+        # Title-path URL under collective + target parent, segments encoded
+        assert link_map["67890"] == \
+            "/apps/collectives/My%20Collective/MigratedPages/Section/Other%20Page"
+
+        md = "see [X](<cpage:67890>) and [Y](<cpage:67890#Heading>) and [Z](<cpage:55>)"
+        out = resolve_page_links(md, link_map)
+        assert "/apps/collectives/My%20Collective/MigratedPages/Section/Other%20Page>" in out
+        assert "Section/Other%20Page#Heading>" in out
+        assert "cpage:55" in out  # unmapped placeholder left as-is
 
 
 class TestConvertPage:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -701,3 +701,14 @@ class TestTemplateConversion:
         # extract (default) keeps the table; exclude drops it — neither errors
         assert "Status" in converter.convert_template({"body": {"storage": {"value": det}}})
         Converter(exclude_details=True).convert_template({"body": {"storage": {"value": det}}})
+
+    def test_storage_status_macro_becomes_inline_code(self, converter):
+        """Storage status lozenges → inline code pills (not [Unsupported macro])."""
+        body = ('<p><ac:structured-macro ac:name="status">'
+                '<ac:parameter ac:name="title">NEU</ac:parameter>'
+                '<ac:parameter ac:name="colour">Blue</ac:parameter></ac:structured-macro>'
+                ' oder <ac:structured-macro ac:name="status">'
+                '<ac:parameter ac:name="title">In Arbeit</ac:parameter></ac:structured-macro></p>')
+        md = converter.convert_template({"body": {"storage": {"value": body}}})
+        assert "`NEU`" in md and "`In Arbeit`" in md
+        assert "Unsupported macro: status" not in md

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -98,11 +98,14 @@ class TestPreprocessImageUrls:
 class TestPreprocessPanels:
     def test_info_panel(self, converter):
         html = '''<div class="confluence-information-macro confluence-information-macro-information">
+            <span class="aui-icon confluence-information-macro-icon"></span>
             <div class="confluence-information-macro-body"><p>Info text</p></div>
         </div>'''
         result = converter.preprocess_html(html)
         assert "<blockquote>" in result
-        assert "Info" in result
+        assert "Info text" in result
+        # No duplicate type label is prepended (the body often self-labels)
+        assert "Info:" not in result
 
     def test_warning_panel(self, converter):
         html = '''<div class="confluence-information-macro confluence-information-macro-warning">
@@ -110,7 +113,8 @@ class TestPreprocessPanels:
         </div>'''
         result = converter.preprocess_html(html)
         assert "<blockquote>" in result
-        assert "Warning" in result
+        assert "Danger!" in result
+        assert "Warning:" not in result
 
     def test_note_panel(self, converter):
         html = '''<div class="confluence-information-macro confluence-information-macro-note">
@@ -118,6 +122,7 @@ class TestPreprocessPanels:
         </div>'''
         result = converter.preprocess_html(html)
         assert "<blockquote>" in result
+        assert "Remember this." in result
 
     def test_tip_panel(self, converter):
         html = '''<div class="confluence-information-macro confluence-information-macro-tip">
@@ -125,7 +130,7 @@ class TestPreprocessPanels:
         </div>'''
         result = converter.preprocess_html(html)
         assert "<blockquote>" in result
-        assert "Tip" in result
+        assert "Pro tip!" in result
 
 
 class TestPreprocessCodeBlocks:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -689,3 +689,15 @@ class TestTemplateConversion:
         md = c.convert_template({"body": {"storage": {"value": det}}})
         assert "Verantwortlicher" not in md
         assert "Unsupported macro: details" not in md
+
+    def test_details_with_nested_macro(self, converter):
+        """A details box nesting another macro (e.g. status) must not error when
+        the parent is processed (regression: decomposing invalidated the nested)."""
+        det = ('<ac:structured-macro ac:name="details"><ac:rich-text-body><table>'
+               '<tr><th>Status</th><td><ac:structured-macro ac:name="status">'
+               '<ac:parameter ac:name="title">offen</ac:parameter>'
+               '</ac:structured-macro></td></tr></table></ac:rich-text-body>'
+               '</ac:structured-macro>')
+        # extract (default) keeps the table; exclude drops it — neither errors
+        assert "Status" in converter.convert_template({"body": {"storage": {"value": det}}})
+        Converter(exclude_details=True).convert_template({"body": {"storage": {"value": det}}})

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -147,6 +147,24 @@ class TestPreprocessCodeBlocks:
         assert "some code" in result
 
 
+class TestPreprocessStatusMacros:
+    def test_status_macro_becomes_code(self, converter):
+        html = '<p>Status: <span class="status-macro aui-lozenge aui-lozenge-current">IN ARBEIT</span></p>'
+        result = converter.preprocess_html(html)
+        assert "<code>IN ARBEIT</code>" in result
+
+    def test_status_macro_inline_code_markdown(self, converter):
+        html = '<p>Status: <span class="status-macro aui-lozenge aui-lozenge-error">ABGELEHNT</span></p>'
+        md = converter.html_to_markdown(converter.preprocess_html(html))
+        assert "`ABGELEHNT`" in md
+
+    def test_empty_status_macro_removed(self, converter):
+        html = '<p>x<span class="status-macro aui-lozenge"></span>y</p>'
+        result = converter.preprocess_html(html)
+        assert "status-macro" not in result
+        assert "<code>" not in result
+
+
 class TestPreprocessMacros:
     def test_unsupported_structured_macro(self, converter):
         html = '<ac:structured-macro ac:name="jira"><ac:parameter ac:name="key">PROJ-1</ac:parameter></ac:structured-macro>'

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
-from migrate import Converter
+from migrate import Converter, resolve_page_links
 
 
 @pytest.fixture
@@ -280,23 +280,43 @@ class TestResolvePageLinks:
         assert page_route_segments("Drafts/Proc/Readme.md") == ["Drafts", "Proc"]
         assert page_route_segments("Readme.md") == []
 
-    def test_build_map_and_resolve(self, tmp_path):
-        from migrate import MigrationState, build_page_link_map, resolve_page_links
+    def test_build_routes_with_and_without_top_folder(self, tmp_path):
+        from migrate import MigrationState, build_page_routes
         state = MigrationState(path=tmp_path / ".migration-state.json")
-        state.set_page("67890", {
-            "page_id": "67890", "space_key": "TEAM", "status": "converted",
-            "convert_path": str(Path("convert_data/TEAM/Section/Other Page.md")),
-        })
-        link_map = build_page_link_map(state, "MigratedPages", "My Collective")
-        # Title-path URL under collective + target parent, segments encoded
-        assert link_map["67890"] == \
-            "/apps/collectives/My%20Collective/MigratedPages/Section/Other%20Page"
+        state.set_page("1", {"page_id": "1", "space_key": "TEAM", "status": "converted",
+                             "convert_path": str(Path("convert_data/TEAM/Section/Other Page.md"))})
+        state.set_page("2", {"page_id": "2", "space_key": "TEAM", "status": "converted",
+                             "convert_path": str(Path("convert_data/TEAM/Readme.md"))})
+        with_top = build_page_routes(state, "Top")
+        assert with_top["1"] == ["Top", "Section", "Other Page"]
+        assert with_top["2"] == ["Top"]            # homepage sits under the wrapper
+        base = build_page_routes(state, "")
+        assert base["1"] == ["Section", "Other Page"]
+        assert base["2"] == []                      # homepage IS the collective root
 
-        md = "see [X](<cpage:67890>) and [Y](<cpage:67890#Heading>) and [Z](<cpage:55>)"
-        out = resolve_page_links(md, link_map)
-        assert "/apps/collectives/My%20Collective/MigratedPages/Section/Other%20Page>" in out
-        assert "Section/Other%20Page#Heading>" in out
-        assert "cpage:55" in out  # unmapped placeholder left as-is
+    def test_relative_route_link(self):
+        from migrate import _relative_route_link
+        # leaf -> sibling leaf
+        assert _relative_route_link(["A", "B", "D"], ["A", "B", "C"]) == "D"
+        # folder/parent page (route A/B) -> its child D
+        assert _relative_route_link(["A", "B", "D"], ["A", "B"]) == "B/D"
+        # any page -> the collective root (homepage)
+        assert _relative_route_link([], ["A", "B"]) == ".."
+        # segments are URL-encoded
+        assert _relative_route_link(["Other Page"], ["Sub", "Leaf"]) == "../Other%20Page"
+
+    def test_resolve_relative_from_normal_page(self):
+        routes = {"1": ["Sec", "Other"], "2": ["Sec", "Cur"]}
+        md = "see [X](<cpage:1>) and [Y](<cpage:1#H>) and [Z](<cpage:99>)"
+        out = resolve_page_links(md, ["Sec", "Cur"], routes, "Coll-9")
+        assert "[X](<Other>)" in out              # relative, collective-agnostic
+        assert "Other#H" in out                   # anchor preserved
+        assert "cpage:99" in out                  # unmigrated target left as-is
+
+    def test_resolve_absolute_from_root_homepage(self):
+        # The collective root page (source_route == []) can't be relative.
+        out = resolve_page_links("[X](<cpage:1>)", [], {"1": ["Vorgabe", "Glossar"]}, "Coll-9")
+        assert "/apps/collectives/Coll-9/Vorgabe/Glossar" in out
 
 
 class TestConvertPage:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -626,3 +626,46 @@ class TestFullConversion:
         assert "API Gateway" in md
         # No block-level headings should remain in table
         assert "<h2>" not in md
+
+
+class TestTemplateConversion:
+    def test_at_var_becomes_placeholder(self, converter):
+        out = converter._substitute_template_variables(
+            'x <at:var at:name="Owner"/> y')
+        assert out == "x {{Owner}} y"
+
+    def test_at_var_paired_form(self, converter):
+        out = converter._substitute_template_variables(
+            'x <at:var at:name="Owner"></at:var> y')
+        assert out == "x {{Owner}} y"
+
+    def test_at_var_name_with_spaces(self, converter):
+        out = converter._substitute_template_variables(
+            'Owner: <at:var at:name="Risk Owner" />')
+        assert out == "Owner: {{Risk Owner}}"
+
+    def test_declarations_stripped(self, converter):
+        out = converter._substitute_template_variables(
+            '<at:declarations><at:string at:name="Owner"/></at:declarations><p>Hi</p>')
+        assert "<at:declarations>" not in out
+        assert "<at:string" not in out
+        assert "<p>Hi</p>" in out
+
+    def test_convert_template_renders_variable_and_macro(self, converter, sample_template):
+        md = converter.convert_template(sample_template)
+        assert "{{Risk Owner}}" in md   # template variable rendered
+        assert "<at:" not in md          # no leftover template tags
+        assert "<ac:" not in md          # macro consumed by preprocess_html
+        # Unexpanded storage macro surfaced as a visible marker (not silently
+        # dropped). Its body ("Fill this in.") is still lost — known limitation.
+        assert "[Unsupported macro: info]" in md
+        assert "Fill this in." not in md
+
+    def test_convert_template_no_attachment_or_comment_section(self, converter, sample_template):
+        md = converter.convert_template(sample_template)
+        assert "## Attachments" not in md
+        assert "## Comments" not in md
+
+    def test_convert_template_empty_body(self, converter):
+        assert converter.convert_template({}) == ""
+        assert converter.convert_template({"body": {}}) == ""

--- a/tests/test_nextcloud_client.py
+++ b/tests/test_nextcloud_client.py
@@ -122,20 +122,64 @@ class TestDavBasePath:
         assert nc.dav_base == "https://nc.example.com/remote.php/dav/files/alice/.Collectives/Team Notes"
 
     def test_verify_connection_falls_back_to_legacy_folder(self, nc):
-        """If '.Collectives' 404s but 'Collectives' exists, use the legacy name."""
+        """If the OCS API has no match and '.Collectives' 404s, use 'Collectives'."""
         def fake_request(method, url, **kwargs):
             resp = MagicMock()
             resp.status_code = 207 if "/.Collectives/" not in url else 404
             return resp
 
-        with patch.object(nc.session, "request", side_effect=fake_request):
+        no_ocs = MagicMock(status_code=404)  # API unavailable -> probe folders
+        with patch.object(nc.session, "get", return_value=no_ocs), \
+                patch.object(nc.session, "request", side_effect=fake_request):
             nc.verify_connection()
         assert nc.collectives_dir == "Collectives"
         assert nc.dav_base.endswith("/Collectives/MyCollective")
 
     def test_verify_connection_prefers_hidden_folder(self, nc):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 207
-        with patch.object(nc.session, "request", return_value=mock_resp):
+        no_ocs = MagicMock(status_code=404)
+        ok = MagicMock(status_code=207)
+        with patch.object(nc.session, "get", return_value=no_ocs), \
+                patch.object(nc.session, "request", return_value=ok):
             nc.verify_connection()
         assert nc.collectives_dir == ".Collectives"
+
+
+class TestResolveCollective:
+    def _client(self, configured):
+        return NextcloudClient("https://nc.example.com", "user", "pw", configured)
+
+    def _ocs(self, collectives, pages):
+        lst = MagicMock(status_code=200)
+        lst.json.return_value = {"ocs": {"data": {"collectives": collectives}}}
+        pg = MagicMock(status_code=200)
+        pg.json.return_value = {"ocs": {"data": {"pages": pages}}}
+        return lambda url, **kw: pg if "/pages" in url else lst
+
+    def test_resolves_localised_folder_name_and_segment(self):
+        nc = self._client("MyTeam-7")  # configured as <slug>-<id>
+        get = self._ocs(
+            [{"id": 7, "name": "My Team", "slug": "MyTeam"}],
+            [{"collectivePath": ".Kollektive/My Team"}],
+        )
+        with patch.object(nc.session, "get", side_effect=get):
+            assert nc.resolve_collective() is True
+        assert nc.collective == "My Team"           # WebDAV folder = display name
+        assert nc.collective_segment == "MyTeam-7"   # link URL segment
+        assert nc.collectives_dir == ".Kollektive"   # localised storage folder
+        assert nc.dav_base.endswith("/.Kollektive/My Team")
+
+    def test_matches_by_display_name(self):
+        nc = self._client("My Team")
+        get = self._ocs([{"id": 7, "name": "My Team", "slug": "MyTeam"}],
+                        [{"collectivePath": ".Collectives/My Team"}])
+        with patch.object(nc.session, "get", side_effect=get):
+            assert nc.resolve_collective() is True
+        assert nc.collective_segment == "MyTeam-7"
+
+    def test_no_match_returns_false(self):
+        nc = self._client("Nope")
+        lst = MagicMock(status_code=200)
+        lst.json.return_value = {"ocs": {"data": {"collectives": [
+            {"id": 1, "name": "Other", "slug": "Other"}]}}}
+        with patch.object(nc.session, "get", return_value=lst):
+            assert nc.resolve_collective() is False

--- a/tests/test_nextcloud_client.py
+++ b/tests/test_nextcloud_client.py
@@ -54,6 +54,17 @@ class TestMkdirP:
             assert urls[1].endswith("/a/b")
             assert urls[2].endswith("/a/b/c")
 
+    def test_backslash_path_normalised(self, nc):
+        """Windows path separators must become '/' in WebDAV URLs (HTTP 400 bug)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 201
+        with patch.object(nc.session, "request", return_value=mock_resp) as mock_req:
+            nc.mkdir_p("a\\b\\c")
+            urls = [c[0][1] for c in mock_req.call_args_list]
+            assert mock_req.call_count == 3
+            assert "\\" not in urls[-1]
+            assert urls[-1].endswith("/a/b/c")
+
     def test_ignores_405_already_exists(self, nc):
         mock_resp = MagicMock()
         mock_resp.status_code = 405  # Already exists
@@ -100,11 +111,31 @@ class TestExists:
 
 
 class TestDavBasePath:
-    def test_dav_base_construction(self):
+    def test_dav_base_defaults_to_hidden_collectives(self):
         nc = NextcloudClient(
             "https://nc.example.com/",  # trailing slash
             "alice",
             "pass",
             "Team Notes",
         )
-        assert nc.dav_base == "https://nc.example.com/remote.php/dav/files/alice/Collectives/Team Notes"
+        # Modern Collectives (4.x) stores pages under the hidden ".Collectives".
+        assert nc.dav_base == "https://nc.example.com/remote.php/dav/files/alice/.Collectives/Team Notes"
+
+    def test_verify_connection_falls_back_to_legacy_folder(self, nc):
+        """If '.Collectives' 404s but 'Collectives' exists, use the legacy name."""
+        def fake_request(method, url, **kwargs):
+            resp = MagicMock()
+            resp.status_code = 207 if "/.Collectives/" not in url else 404
+            return resp
+
+        with patch.object(nc.session, "request", side_effect=fake_request):
+            nc.verify_connection()
+        assert nc.collectives_dir == "Collectives"
+        assert nc.dav_base.endswith("/Collectives/MyCollective")
+
+    def test_verify_connection_prefers_hidden_folder(self, nc):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 207
+        with patch.object(nc.session, "request", return_value=mock_resp):
+            nc.verify_connection()
+        assert nc.collectives_dir == ".Collectives"

--- a/tests/test_nextcloud_client.py
+++ b/tests/test_nextcloud_client.py
@@ -183,3 +183,49 @@ class TestResolveCollective:
             {"id": 1, "name": "Other", "slug": "Other"}]}}}
         with patch.object(nc.session, "get", return_value=lst):
             assert nc.resolve_collective() is False
+
+
+class TestEnsureTemplatesFolder:
+    def test_creates_and_seeds_index(self, nc):
+        def req(method, url, **kw):
+            r = MagicMock()
+            r.status_code = 201 if method == "MKCOL" else 404  # PROPFIND → not found
+            return r
+
+        put_resp = MagicMock(status_code=201)
+        with patch.object(nc.session, "request", side_effect=req) as mock_req, \
+             patch.object(nc.session, "put", return_value=put_resp) as mock_put:
+            nc.ensure_templates_folder()
+            mkcol = [c for c in mock_req.call_args_list if c[0][0] == "MKCOL"]
+            assert len(mkcol) == 1
+            assert mkcol[0][0][1].endswith("/.templates")
+            assert mock_put.call_count == 1
+            assert mock_put.call_args[0][0].endswith("/.templates/Readme.md")
+            assert b"template files for the collective" in mock_put.call_args.kwargs["data"]
+
+    def test_skips_index_when_present(self, nc):
+        def req(method, url, **kw):
+            r = MagicMock()
+            r.status_code = 201 if method == "MKCOL" else 207  # PROPFIND → exists
+            return r
+
+        with patch.object(nc.session, "request", side_effect=req), \
+             patch.object(nc.session, "put") as mock_put:
+            nc.ensure_templates_folder()
+            mock_put.assert_not_called()
+
+
+class TestUploadTemplate:
+    def test_puts_to_templates_path(self, nc):
+        put_resp = MagicMock(status_code=201)
+        with patch.object(nc.session, "put", return_value=put_resp) as mock_put:
+            remote = nc.upload_template("My Template", "# Body")
+            assert remote == ".templates/My Template.md"
+            assert mock_put.call_args[0][0].endswith("/.templates/My Template.md")
+            assert mock_put.call_args.kwargs["data"] == b"# Body"
+
+    def test_raises_on_bad_status(self, nc):
+        put_resp = MagicMock(status_code=500)
+        with patch.object(nc.session, "put", return_value=put_resp):
+            with pytest.raises(click.ClickException, match="Upload failed"):
+                nc.upload_template("X", "y")


### PR DESCRIPTION
## Summary
Makes migrations usable for spaces whose pages cross‑reference each other and embed diagrams, and adds support for modern/localized Nextcloud Collectives. Validated end‑to‑end against an 84‑page space (1090 internal links, 65 images) on both an English and a German (`.Kollektive`) Collectives 4.x instance. Full test suite passes.

> Note: this builds on #5 (the two bug fixes); until that merges, this PR's diff also includes those two fixes.

## Features
### Internal page links (relative, move‑safe)
Inter‑page links kept their `atlassian.net` URLs and broke after migration. The converter now tags links to other migrated pages with a `cpage:<id>` placeholder; the upload phase resolves each, per source page, into a **relative** link between the output pages. Relative links are collective‑agnostic, so they keep working if the collective is renamed or its pages are moved to another collective. The one exception is the collective's root/landing page (no trailing URL segment to be relative to), whose links use the absolute `/apps/collectives/<slug>-<id>/...` form.

### Diagram & image rendering
draw.io/Gliffy/etc. macros were replaced with an HTML comment, discarding the PNG preview that `export_view` embeds inside them. The macro's rendered `<img>` is now lifted out before the macro is dropped, so diagrams render as static images. (SVG stays demoted to an attachment link, since Collectives blocks SVG rendering.)

### Modern / localized / shared Collectives
`verify_connection` resolves the collective via the Collectives OCS API, matching `NEXTCLOUD_COLLECTIVE` by name / slug / `<slug>-<id>`. This handles the hidden, **localized** storage folder (a German Nextcloud uses `.Kollektive`, not `.Collectives` — read from a page's `collectivePath`), the WebDAV folder being the display name, and derives the `<slug>-<id>` link segment. Falls back to probing `.Collectives`/`Collectives`. Attachment links use the open‑by‑id `…/f/<id>` URL so they open even from the hidden folder.

### Base‑folder import
`--target-parent ''` imports directly at the collective base (the space homepage becomes the landing page) instead of nesting under a top folder.

## Formatting
- Attachment lists keep their `-` bullets (a rewrite was stripping them).
- Info/Warning/Note/Tip panels become plain blockquotes without a duplicated `Info:`/`Note:` label.

## Testing
Unit tests across converter / Confluence / Nextcloud clients; end‑to‑end browser‑simulated resolution of every internal link landed on the correct page.
